### PR TITLE
Moving the $json variable

### DIFF
--- a/includes/display/processing/post-process.php
+++ b/includes/display/processing/post-process.php
@@ -4,7 +4,7 @@ function ninja_forms_post_process(){
 
 	$ajax = $ninja_forms_processing->get_form_setting('ajax');
 	$form_id = $ninja_forms_processing->get_form_ID();
-
+	$json = ninja_forms_json_response();
 	if(!$ninja_forms_processing->get_all_errors()){
 
 		do_action('ninja_forms_post_process');
@@ -12,8 +12,6 @@ function ninja_forms_post_process(){
 		if( !$ninja_forms_processing->get_all_errors() ){
 
 			$ninja_forms_processing->update_form_setting( 'processing_complete', 1 );
-
-			$json = ninja_forms_json_response();
 			
 			if($ajax == 1){
 				//header('Content-Type', 'application/json');


### PR DESCRIPTION
If one adds an error though the ninja_forms_process action, then the $json variable will not be set and get the error : 
Undefined variable: json in ..../wp-content/plugins/ninja-forms/includes/display/processing/post-process.php 

According to the documentation one should be able to add errors on that action.