### PR TITLE
fix wp-cli plugin activation issue

### DIFF
--- a/includes/activation.php
+++ b/includes/activation.php
@@ -89,7 +89,10 @@ function ninja_forms_activation( $network_wide ){
 		) DEFAULT CHARSET=utf8;";
 
 		dbDelta($sql);
-
+		
+		if (!function_exists('nf_change_email_fav')){
+  			require_once __DIR__.'/admin/upgrades/upgrade-functions.php';
+		}
 		// Remove old email settings.
 		nf_change_email_fav();
 

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -91,7 +91,7 @@ function ninja_forms_activation( $network_wide ){
 		dbDelta($sql);
 		
 		if (!function_exists('nf_change_email_fav')){
-  			require_once __DIR__.'/admin/upgrades/upgrade-functions.php';
+  			require_once dirname(__FILE__).'/admin/upgrades/upgrade-functions.php';
 		}
 		// Remove old email settings.
 		nf_change_email_fav();


### PR DESCRIPTION
this will solve a "unknown function nf_change_email_fav" fatal error when activating ninja forms through wp-cli