### PR TITLE
Bug fix for when the value is "0" with inside labels

### DIFF
--- a/includes/display/processing/req-fields-pre-process.php
+++ b/includes/display/processing/req-fields-pre-process.php
@@ -83,7 +83,7 @@ function ninja_forms_req_fields_process(){
 						}
 					}else{
 						if($label_pos == 'inside'){
-							if( $user_value == $label OR empty( $user_value ) ){
+							if( $user_value == $label OR ( empty( $user_value ) && $user_value !== "0" ) ){
 								$ninja_forms_processing->add_error('required-'.$field_id, $req_field_error, $field_id);
 								$ninja_forms_processing->add_error('required-general', $req_error_label, 'general');
 							}


### PR DESCRIPTION
When a field is required and you're using inside label positions, if the
value is "0" then it will always fail the validation without this fix