### PR TITLE
[Hotfix] Number field attributes space bugfix, which causes invalid name attr.

### DIFF
--- a/includes/fields/number.php
+++ b/includes/fields/number.php
@@ -97,19 +97,19 @@ function ninja_forms_field_number_display( $field_id, $data, $form_id = '' ) {
 	}
 
 	if ( isset( $data['number_min'] ) ) {
-		$min = 'min="' . esc_attr( $data['number_min'] ) . '"';
+		$min = ' min="' . esc_attr( $data['number_min'] ) . '"';
 	} else {
 		$min = '';
 	}
 
 	if ( isset( $data['number_max'] ) ) {
-		$max = 'max="' . esc_attr( $data['number_max'] ) . '"';
+		$max = ' max="' . esc_attr( $data['number_max'] ) . '"';
 	} else {
 		$max = '';
 	}
 
 	if ( isset( $data['number_step'] ) ) {
-		$step = 'step="' . esc_attr( $data['number_step'] ) . '"';
+		$step = ' step="' . esc_attr( $data['number_step'] ) . '"';
 	} else {
 		$step = '';
 	}
@@ -117,6 +117,6 @@ function ninja_forms_field_number_display( $field_id, $data, $form_id = '' ) {
 	$field_class = ninja_forms_get_field_class( $field_id, $form_id );
 
 ?>
-		<input type="number" <?php echo $min . $max . $step; ?>name="ninja_forms_field_<?php echo esc_attr( $field_id ); ?>" id="ninja_forms_field_<?php echo esc_attr( $field_id ); ?>" class="<?php echo esc_attr( $field_class ); ?>" rel="<?php echo esc_attr( $field_id ); ?>" value="<?php echo esc_attr( $default_value ); ?>"/>
+		<input type="number"<?php echo $min . $max . $step; ?> name="ninja_forms_field_<?php echo esc_attr( $field_id ); ?>" id="ninja_forms_field_<?php echo esc_attr( $field_id ); ?>" class="<?php echo esc_attr( $field_class ); ?>" rel="<?php echo esc_attr( $field_id ); ?>" value="<?php echo esc_attr( $default_value ); ?>"/>
 <?php
 }


### PR DESCRIPTION
This hotfix solves the problem that attributes in number field type are concatenated without space. This propagates the problem, that `name` parameter is invalid and browser do not send field's value and it is empty (`false`) while processing form submission - user cannot ubmit data from this field.

Please merge to master ASAP!