### PR TITLE
add HTML placeholders for text inputs

### DIFF
--- a/includes/admin/edit-field/placeholder.php
+++ b/includes/admin/edit-field/placeholder.php
@@ -1,0 +1,23 @@
+<?php
+add_action('init', 'ninja_forms_register_edit_field_placeholder');
+function ninja_forms_register_edit_field_placeholder(){
+	add_action('ninja_forms_edit_field_before_registered', 'ninja_forms_edit_field_placeholder', 10);
+}
+
+function ninja_forms_edit_field_placeholder($field_id){
+	global $ninja_forms_fields;
+	$field_row = ninja_forms_get_field_by_id($field_id);
+	$field_type = $field_row['type'];
+	$field_data = $field_row['data'];
+	$reg_field = $ninja_forms_fields[$field_type];
+	$edit_placeholder = $reg_field['edit_placeholder'];
+	if($edit_placeholder){
+		if(isset($field_data['placeholder'])){
+			$placeholder = stripslashes($field_data['placeholder']);
+		}else{
+			$placeholder = '';
+		}
+
+		ninja_forms_edit_field_el_output($field_id, 'text', __( 'Placeholder', 'ninja-forms' ), 'placeholder', $placeholder, 'wide', '', 'widefat ninja-forms-field-label');
+	}
+}

--- a/includes/fields/textbox.php
+++ b/includes/fields/textbox.php
@@ -83,6 +83,7 @@ function ninja_forms_register_field_textbox(){
 		'group' => 'standard_fields',
 		'edit_label' => true,
 		'edit_label_pos' => true,
+		'edit_placeholder' => true,
 		'edit_req' => true,
 		'edit_custom_class' => true,
 		'edit_help' => true,
@@ -223,6 +224,12 @@ function ninja_forms_field_text_display( $field_id, $data, $form_id = '' ){
 		$label = '';
 	}
 
+	if(isset($data['placeholder'])){
+		$placeholder = $data['placeholder'];
+	}else{
+		$placeholder = '';
+	}
+
 	if( isset( $data['mask'] ) ){
 		$mask = $data['mask'];
 	}else{
@@ -267,7 +274,7 @@ function ninja_forms_field_text_display( $field_id, $data, $form_id = '' ){
 	}
 
 	?>
-	<input id="ninja_forms_field_<?php echo $field_id;?>" data-mask="<?php echo $mask;?>" data-input-limit="<?php echo $input_limit;?>" data-input-limit-type="<?php echo $input_limit_type;?>" data-input-limit-msg="<?php echo $input_limit_msg;?>" name="ninja_forms_field_<?php echo $field_id;?>" type="text" class="<?php echo $field_class;?> <?php echo $mask_class;?>" value="<?php echo $default_value;?>" rel="<?php echo $field_id;?>" />
+	<input id="ninja_forms_field_<?php echo $field_id;?>" data-mask="<?php echo $mask;?>" data-input-limit="<?php echo $input_limit;?>" data-input-limit-type="<?php echo $input_limit_type;?>" data-input-limit-msg="<?php echo $input_limit_msg;?>" name="ninja_forms_field_<?php echo $field_id;?>" type="text" placeholder="<?php echo $placeholder;?>" class="<?php echo $field_class;?> <?php echo $mask_class;?>" value="<?php echo $default_value;?>" rel="<?php echo $field_id;?>" />
 	<?php
 
 }

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -458,6 +458,7 @@ class Ninja_Forms {
 		//Edit Field Functions
 		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/edit-field.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/label.php" );
+		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/placeholder.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/hr.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/req.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/admin/edit-field/custom-class.php" );


### PR DESCRIPTION
I'm about done w/ this for calc fields too, but then i started thinking about whether or not a calc field would need it. currently, a calc field with no value will show a zero as the calculated value. 

my end goal was to create a set of radio buttons that changed the calc field, but that you could also adjust manually. but it might be better to just do a bit of quick JS on my end. 

[] option1 [] option2 [ Enter Your own ]

