### PR TITLE
Card Declined Error Notice

### DIFF
--- a/includes/fields/credit-card.php
+++ b/includes/fields/credit-card.php
@@ -222,7 +222,7 @@ function ninja_forms_field_credit_card_display( $field_id, $data, $form_id = '' 
 			?>
 		</div>
 		<div>
-			<div class="ninja-forms-credit-card-number-error ninja-forms-field-error">
+			<div id="ninja_forms_field_credit_card_number_error" class="ninja-forms-credit-card-number-error ninja-forms-field-error">
 				<?php
 				if ( $card_number_errors ) {
 					if( is_array( $card_number_errors ) ) {


### PR DESCRIPTION
The credit card field type was missing the conventional id, so the JS was not attaching the error message to the field when a card was declined (via AJAX).