### PR TITLE
Feature/form caching

### DIFF
--- a/includes/admin/ajax.php
+++ b/includes/admin/ajax.php
@@ -127,6 +127,9 @@ function nf_admin_save_builder() {
 		Ninja_Forms()->form( $form_id )->update_setting( 'status', '' );
 	}
 
+	// Dump our current form transient.
+	delete_transient( 'nf_form_' . $form_id );
+
 	die();
 }
 

--- a/includes/admin/save.php
+++ b/includes/admin/save.php
@@ -10,11 +10,15 @@ function ninja_forms_admin_save(){
 			$data_array = array();
 			if ( isset( $_REQUEST['form_id'] ) and $_REQUEST['form_id'] != 'new' ) {
 				$form_id = absint( $_REQUEST['form_id'] );
+
+				// Dump our current form transient.
+				delete_transient( 'nf_form_' . $form_id );
 			} else if ( isset ( $_REQUEST['form_id'] ) and $_REQUEST['form_id'] == 'new' ) {
 				$form_id = 'new';
 			} else {
 				$form_id = '';
 			}
+
 			foreach ( $_POST as $key => $val ) {
 				if ( substr($key, 0, 1) != '_') {
 					$data_array[$key] = $val;
@@ -109,7 +113,7 @@ function ninja_forms_admin_save(){
 				$redirect_array = array( 'update_message' => urlencode( $ninja_forms_admin_update_message ) );
 				$url = esc_url_raw( add_query_arg( $redirect_array ) );
 				wp_redirect( $url );
-			}		
+			}
 		}
 	}
 }

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -246,7 +246,7 @@ class Ninja_Forms {
 	 *
 	 * @access public
 	 * @param int $form_id
-	 * @since 2.7
+	 * @since 2.9.11
 	 * @return object self::$instance->form_var
 	 */
 	public function form( $form_id = '' ) {

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -253,10 +253,19 @@ class Ninja_Forms {
 		// Bail if we don't get a form id.
 
 		$form_var = 'form_' . $form_id;
-		// Check to see if an object for this form already exists
-		// Create one if it doesn't exist.
-		if ( ! isset( self::$instance->$form_var ) )
+		// Check to see if an object for this form already exists in memory. If it does, return it.
+		if ( isset( self::$instance->$form_var ) )
+			return self::$instance->$form_var;
+		
+		// Check to see if we have a transient object stored for this form.
+		if ( false != ( $form_obj = get_transient( 'nf_form_' . $form_id ) ) ) {
+			self::$instance->$form_var = $form_obj;
+		} else {
+			// Create a new form object for this form.
 			self::$instance->$form_var = new NF_Form( $form_id );
+			// Save it into a transient.
+			set_transient( 'nf_form_' . $form_id, self::$instance->$form_var, DAY_IN_SECONDS );
+		}
 
 		return self::$instance->$form_var;
 	}


### PR DESCRIPTION
Added an object caching layer using the WordPress transient API. This stores form objects and retrieves them from the transient cache so that a call to the database doesn't have to be made for each form/field/notification/etc. when a form object is created. Eventually, this caching will be ported over to fields and notifications as well.