### PR TITLE
Set $display_style

### DIFF
--- a/includes/fields/list.php
+++ b/includes/fields/list.php
@@ -725,6 +725,12 @@ function nf_field_list_edit_sub_value( $field_id, $user_value, $field ) {
 						$label = '';
 					}
 
+					if(isset($option['display_style'])){
+						$display_style = $option['display_style'];
+					}else{
+						$display_style = '';
+					}
+
 					if ( isset( $option['disabled'] ) AND $option['disabled'] ){
 						$disabled = 'disabled';
 					}else{


### PR DESCRIPTION
Fixes #657

Although this fixes the PHP notice, I'm not seeing any `$display_style` in the `$option` array. It looks like this might have just been a left over variable after a copy and paste, correct me if I'm wrong. Removing it would be another option, let me know!