### PR TITLE
Add reCAPTCHA Field

### DIFF
--- a/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -89,6 +89,7 @@ function ninja_forms_register_general_settings_metabox(){
 		'state' => 'closed',
 	);
     $args['settings'] = apply_filters( 'nf_general_settings_advanced', $args['settings'] );
+
 	ninja_forms_register_tab_metabox( $args );
 
 }

--- a/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -50,7 +50,7 @@ function ninja_forms_register_general_settings_metabox(){
 				'name' 	=> 'recaptcha_site_key',
 				'type' 	=> 'text',
 				'label' => __( 'reCAPTCHA Site Key', 'ninja-forms' ),
-				'desc' 	=> '',
+				'desc' 	=>  sprintf( __( 'Get site key for your domain by registering  %shere%s', 'ninja-forms' ), '<a href="https://www.google.com/recaptcha/intro/index.html" target="_blank">', '</a>' )
 			),
 			array(
 				'name' 	=> 'recaptcha_secret_key',

--- a/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -46,9 +46,27 @@ function ninja_forms_register_general_settings_metabox(){
 				'label' => __( 'Currency Symbol', 'ninja-forms' ),
 				'desc' 	=> 'e.g. $, &pound;, &euro;',
 			),
+			array(
+				'name' 	=> 'recaptcha_site_key',
+				'type' 	=> 'text',
+				'label' => __( 'reCAPTCHA Site Key', 'ninja-forms' ),
+				'desc' 	=> '',
+			),
+			array(
+				'name' 	=> 'recaptcha_secret_key',
+				'type' 	=> 'text',
+				'label' => __( 'reCAPTCHA Secret Key', 'ninja-forms' ),
+				'desc' 	=> '',
+			),
+			array(
+				'name' 	=> 'recaptcha_lang',
+				'type' 	=> 'text',
+				'label' => __( 'reCAPTCHA Language', 'ninja-forms' ),
+				'desc' 	=> 'e.g. en, da - ' . sprintf( __( 'Language of reCAPTCHA.To get code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
+			),
 		),
 	);
-	ninja_forms_register_tab_metabox( $args );	
+	ninja_forms_register_tab_metabox( $args );
 
 	$args = array(
 		'page' => 'ninja-forms-settings',

--- a/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -89,7 +89,6 @@ function ninja_forms_register_general_settings_metabox(){
 		'state' => 'closed',
 	);
     $args['settings'] = apply_filters( 'nf_general_settings_advanced', $args['settings'] );
-
 	ninja_forms_register_tab_metabox( $args );
 
 }

--- a/includes/fields/recaptcha.php
+++ b/includes/fields/recaptcha.php
@@ -48,8 +48,8 @@ function ninja_forms_field_recaptcha_pre_process( $field_id, $user_value  ) {
 		$ninja_forms_processing->add_error( 'error_recaptcha', __( 'Please enter value in captcha field' , 'ninja-forms' ) );
 	}else {
 		$settings = get_option( 'ninja_forms_settings' );
-		$url = 'https://www.google.com/recaptcha/api/siteverify?secret='.$settings['recaptcha_secret_key'].'&response='.$_POST['g-recaptcha-response'];
-		$resp = wp_remote_get( $url, array( 'sslverify'=>true ) );
+		$url = 'https://www.google.com/recaptcha/api/siteverify?secret='.$settings['recaptcha_secret_key'].'&response='.sanitize_text_field( $_POST['g-recaptcha-response'] );
+		$resp = wp_remote_get( esc_url_raw( $url ) );
 
 		if ( !is_wp_error( $resp ) ) {
 			$body = wp_remote_retrieve_body( $resp );

--- a/includes/fields/recaptcha.php
+++ b/includes/fields/recaptcha.php
@@ -1,5 +1,7 @@
 <?php if ( ! defined( 'ABSPATH' ) ) exit;
 function ninja_forms_register_field_recaptcha() {
+
+	$settings = get_option( "ninja_forms_settings" );
 	$args = array(
 		'name' => __( 'reCAPTCHA', 'ninja-forms' ),
 		'sidebar' => 'template_fields',
@@ -22,8 +24,10 @@ function ninja_forms_register_field_recaptcha() {
 		'pre_process' => 'ninja_forms_field_recaptcha_pre_process',
 
 	);
-
-	ninja_forms_register_field( '_recaptcha', $args );
+	// show recaptcha field in admin only if site and secret key exists.
+	if ( !empty( $settings['recaptcha_site_key'] ) && !empty( $settings['recaptcha_secret_key'] ) ) {
+		ninja_forms_register_field( '_recaptcha', $args );
+	}
 }
 
 add_action( 'init', 'ninja_forms_register_field_recaptcha' );

--- a/includes/fields/recaptcha.php
+++ b/includes/fields/recaptcha.php
@@ -1,0 +1,68 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit;
+function ninja_forms_register_field_recaptcha() {
+	$args = array(
+		'name' => __( 'reCAPTCHA', 'ninja-forms' ),
+		'sidebar' => 'template_fields',
+		'edit_function' => '',
+		'display_function' => 'ninja_forms_field_recaptcha_display',
+		'save_function' => '',
+		'group' => 'standard_fields',
+		'default_label' => __( 'Confirm that you are not a bot', 'ninja-forms' ),
+		'edit_label' => true,
+		'req' => true,
+		'edit_label_pos' => true,
+		'edit_req' => false,
+		'edit_custom_class' => false,
+		'edit_help' => false,
+		'edit_meta' => false,
+		'sidebar' => 'template_fields',
+		'edit_conditional' => false,
+		'display_label' => true,
+		'process_field' => false,
+		'pre_process' => 'ninja_forms_field_recaptcha_pre_process',
+
+	);
+
+	ninja_forms_register_field( '_recaptcha', $args );
+}
+
+add_action( 'init', 'ninja_forms_register_field_recaptcha' );
+
+function ninja_forms_field_recaptcha_display( $field_id, $data, $form_id = '' ) {
+	$settings = get_option( "ninja_forms_settings" );
+	$lang = $settings['recaptcha_lang'];
+	$siteKey = $settings['recaptcha_site_key'];
+	if ( !empty( $siteKey ) ) { ?>
+
+		<div class="g-recaptcha" data-sitekey="<?php echo $siteKey; ?>"></div>
+        <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=<?php echo $lang; ?>"> </script>
+
+		<?php
+	}
+}
+
+function ninja_forms_field_recaptcha_pre_process( $field_id, $user_value  ) {
+	global $ninja_forms_processing;
+
+	if ( empty( $_POST['g-recaptcha-response'] ) ) {
+		$ninja_forms_processing->add_error( 'error_recaptcha', __( 'Please enter value in captcha field' , 'ninja-forms' ) );
+	}else {
+		$settings = get_option( 'ninja_forms_settings' );
+		$url = 'https://www.google.com/recaptcha/api/siteverify?secret='.$settings['recaptcha_secret_key'].'&response='.$_POST['g-recaptcha-response'];
+		$resp = wp_remote_get( $url, array( 'sslverify'=>true ) );
+
+		if ( !is_wp_error( $resp ) ) {
+			$body = wp_remote_retrieve_body( $resp );
+			$response = json_decode( $body );
+			if ( $response->success===false ) {
+				if ( !empty( $response->{'error-codes'} ) && $response->{'error-codes'} != 'missing-input-response' ) {
+					$error= __( 'Please check if you have entered Site & Secret key correctly', 'ninja-forms' );
+				}else {
+					$error= __( 'Captcha mismatch, Please enter correct value in captcha field', 'ninja-forms' );
+				}
+				$ninja_forms_processing->add_error( 'error_recaptcha', $error );
+			}
+		}
+	}
+
+}

--- a/includes/fields/recaptcha.php
+++ b/includes/fields/recaptcha.php
@@ -37,10 +37,14 @@ function ninja_forms_field_recaptcha_display( $field_id, $data, $form_id = '' ) 
 	$lang = $settings['recaptcha_lang'];
 	$siteKey = $settings['recaptcha_site_key'];
 	if ( !empty( $siteKey ) ) { ?>
-
-		<div class="g-recaptcha" data-sitekey="<?php echo $siteKey; ?>"></div>
+		<input id="ninja_forms_field_<?php echo $field_id;?>" name="ninja_forms_field_<?php echo $field_id;?>" type="hidden" class="<?php echo $field_class;?>" value="" rel="<?php echo $field_id;?>" />
+		<div class="g-recaptcha" data-callback="nf_recaptcha_set_field_value" data-sitekey="<?php echo $siteKey; ?>"></div>
         <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=<?php echo $lang; ?>"> </script>
-
+		<script type="text/javascript">
+            function nf_recaptcha_set_field_value(inpval){
+            	jQuery("#ninja_forms_field_<?php echo $field_id;?>").val(inpval)
+            }
+            </script>
 		<?php
 	}
 }

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -592,6 +592,7 @@ class Ninja_Forms {
 		require_once( NINJA_FORMS_DIR . "/includes/fields/tax.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/fields/credit-card.php" );
 		require_once( NINJA_FORMS_DIR . "/includes/fields/number.php" );
+		require_once( NINJA_FORMS_DIR . "/includes/fields/recaptcha.php" );
 
 		require_once( NINJA_FORMS_DIR . "/includes/admin/save.php" );
 	}
@@ -673,6 +674,7 @@ class Ninja_Forms {
 
 	  $settings['date_format'] = isset ( $settings['date_format'] ) ? $settings['date_format'] : 'd/m/Y';
 	  $settings['currency_symbol'] = isset ( $settings['currency_symbol'] ) ? $settings['currency_symbol'] : '$';
+	  $settings['recaptcha_lang'] = isset ( $settings['recaptcha_lang'] ) ? $settings['recaptcha_lang'] : 'en';
 	  $settings['req_div_label'] = isset ( $settings['req_div_label'] ) ? $settings['req_div_label'] : sprintf( __( 'Fields marked with an %s*%s are required', 'ninja-forms' ), '<span class="ninja-forms-req-symbol">','</span>' );
 	  $settings['req_field_symbol'] = isset ( $settings['req_field_symbol'] ) ? $settings['req_field_symbol'] : '<strong>*</strong>';
 	  $settings['req_error_label'] = isset ( $settings['req_error_label'] ) ? $settings['req_error_label'] : __( 'Please ensure all required fields are completed.', 'ninja-forms' );
@@ -704,7 +706,7 @@ class Ninja_Forms {
 
 	/**
 	 * Refresh our plugin settings if we update the ninja_forms_settings option
-	 * 
+	 *
 	 * @access public
 	 * @since 2.9
 	 * @return void


### PR DESCRIPTION
Adds a google reCAPTCHA field.

I have added the site key, secret & language under general setting, let me know if it should be somewhere else.


![screen shot 2015-04-24 at 7 53 50 pm](https://cloud.githubusercontent.com/assets/1675046/7320688/b8ee8bea-eabb-11e4-8491-a2564222674e.png)

The new reCAPTCHA field is available under template fields section on edit form page.

![screen shot 2015-04-24 at 7 59 22 pm](https://cloud.githubusercontent.com/assets/1675046/7320921/e9b392ba-eabc-11e4-806a-1b8e88347349.png)



