### PR TITLE
initialize $args property as array

### DIFF
--- a/includes/admin/upgrades/class-upgrade-handler.php
+++ b/includes/admin/upgrades/class-upgrade-handler.php
@@ -17,6 +17,8 @@ class NF_UpgradeHandler
 
     private $page;
 
+    public $args = array();
+
     public static function instance()
     {
         if ( ! isset( self::$instance ) ) {


### PR DESCRIPTION
No reported issues yet, but the $args property implicitly an array. Now it is explicit and documented. Closes #702.