### PR TITLE
Issue/722

### DIFF
--- a/assets/js/dev/subs-cpt.js
+++ b/assets/js/dev/subs-cpt.js
@@ -56,5 +56,4 @@ jQuery(document).ready(function($) {
 
 	$( '.screen-options' ).prepend( $( '#nf-subs-screen-options' ).html() );
 	$( '#nf-subs-screen-options' ).remove();
-
 });

--- a/assets/js/dev/subs-cpt.js
+++ b/assets/js/dev/subs-cpt.js
@@ -56,4 +56,5 @@ jQuery(document).ready(function($) {
 
 	$( '.screen-options' ).prepend( $( '#nf-subs-screen-options' ).html() );
 	$( '#nf-subs-screen-options' ).remove();
+	
 });

--- a/classes/form.php
+++ b/classes/form.php
@@ -111,7 +111,10 @@ class NF_Form {
 	 * @since 2.7
 	 * @return string $setting
 	 */
-	public function get_setting( $setting ) {
+	public function get_setting( $setting, $bypass_cache = false ) {
+		if ( $bypass_cache ) {
+			return nf_get_object_meta_value( $this->form_id, 'last_sub' );
+		}
 		if ( isset ( $this->settings[ $setting ] ) ) {
 			return $this->settings[ $setting ];
 		} else {

--- a/classes/subs-cpt.php
+++ b/classes/subs-cpt.php
@@ -236,13 +236,11 @@ class NF_Subs_CPT {
 			$datepicker_args['dateFormat'] = $date_format;
 		}
 
-		ninja_forms_admin_js();
-
 		wp_enqueue_script( 'subs-cpt',
 			NF_PLUGIN_URL . 'assets/js/' . $src .'/subs-cpt' . $suffix . '.js',
 			array('jquery', 'jquery-ui-datepicker') );
 
-		wp_localize_script( 'subs-cpt', 'nf_sub', array( 'form_id' => $form_id, 'reset_seq_num_title' => __( 'Re-number Submissions', 'ninja-forms' ), 'datepicker_args' => apply_filters( 'ninja_forms_admin_submissions_datepicker_args', $datepicker_args ) ) );
+		wp_localize_script( 'subs-cpt', 'nf_sub', array( 'form_id' => $form_id, 'datepicker_args' => apply_filters( 'ninja_forms_admin_submissions_datepicker_args', $datepicker_args ) ) );
 
 	}
 
@@ -259,8 +257,6 @@ class NF_Subs_CPT {
 		// Bail if we aren't on the edit.php page or the post.php page.
 		if ( ( $pagenow != 'edit.php' && $pagenow != 'post.php' ) || $typenow != 'nf_sub' )
 			return false;
-
-		ninja_forms_admin_css();
 		
 		wp_enqueue_style( 'nf-sub', NF_PLUGIN_URL .'assets/css/cpt.css' );
 		wp_enqueue_style( 'nf-jquery-ui-freshness', NF_PLUGIN_URL .'assets/css/jquery-ui-fresh.min.css' );

--- a/classes/subs-cpt.php
+++ b/classes/subs-cpt.php
@@ -236,11 +236,13 @@ class NF_Subs_CPT {
 			$datepicker_args['dateFormat'] = $date_format;
 		}
 
+		ninja_forms_admin_js();
+
 		wp_enqueue_script( 'subs-cpt',
 			NF_PLUGIN_URL . 'assets/js/' . $src .'/subs-cpt' . $suffix . '.js',
 			array('jquery', 'jquery-ui-datepicker') );
 
-		wp_localize_script( 'subs-cpt', 'nf_sub', array( 'form_id' => $form_id, 'datepicker_args' => apply_filters( 'ninja_forms_admin_submissions_datepicker_args', $datepicker_args ) ) );
+		wp_localize_script( 'subs-cpt', 'nf_sub', array( 'form_id' => $form_id, 'reset_seq_num_title' => __( 'Re-number Submissions', 'ninja-forms' ), 'datepicker_args' => apply_filters( 'ninja_forms_admin_submissions_datepicker_args', $datepicker_args ) ) );
 
 	}
 
@@ -257,6 +259,8 @@ class NF_Subs_CPT {
 		// Bail if we aren't on the edit.php page or the post.php page.
 		if ( ( $pagenow != 'edit.php' && $pagenow != 'post.php' ) || $typenow != 'nf_sub' )
 			return false;
+
+		ninja_forms_admin_css();
 		
 		wp_enqueue_style( 'nf-sub', NF_PLUGIN_URL .'assets/css/cpt.css' );
 		wp_enqueue_style( 'nf-jquery-ui-freshness', NF_PLUGIN_URL .'assets/css/jquery-ui-fresh.min.css' );

--- a/classes/subs.php
+++ b/classes/subs.php
@@ -42,7 +42,7 @@ class NF_Subs {
 		Ninja_Forms()->sub( $sub_id )->update_form_id( $form_id );
 
 		// Get the current sequential ID
-		$last_sub = Ninja_Forms()->form( $form_id )->get_setting( 'last_sub' );
+		$last_sub = Ninja_Forms()->form( $form_id )->get_setting( 'last_sub', true );
 		$seq_num = ! empty ( $last_sub ) ? $last_sub + 1 : 1;
 
 		$seq_num = apply_filters( 'nf_sub_seq_num', $seq_num, $form_id );

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -387,7 +387,6 @@ class Ninja_Forms {
 			require_once( NF_PLUGIN_DIR . 'includes/admin/step-processing.php' );
 			require_once( NF_PLUGIN_DIR . 'classes/step-processing.php' );
 
-
 			// Include our download all submissions php files
 			require_once( NF_PLUGIN_DIR . 'classes/download-all-subs.php' );
 


### PR DESCRIPTION
Closes #722.

Added an option to the Ninja_Forms()->form( 3 )->get_setting() method for bypassing the cache. This will cause the setting to be grabbed from the database rather than the form cache. This is used for the seq_num to prevent caching issues.

Created a plugin: https://github.com/wpninjas/ninja-forms-renumber-subs to handle renumbering submissions. This will fix any subs already created.