### PR TITLE
Removes wrapping div from response messages

### DIFF
--- a/includes/display/form/response-message.php
+++ b/includes/display/form/response-message.php
@@ -43,18 +43,14 @@ function ninja_forms_display_response_message( $form_id ){
 				if( $ninja_forms_processing->get_form_ID() == $form_id ){
 					if( $ninja_forms_processing->get_errors_by_location('general') ){
 						foreach($ninja_forms_processing->get_errors_by_location('general') as $error){
-							echo '<div>';
 							echo $error['msg'];
-							echo '</div>';
 						}
 					}
 
 
 					if( $ninja_forms_processing->get_all_success_msgs()){
 						foreach($ninja_forms_processing->get_all_success_msgs() as $success){
-							echo '<div>';
 							echo $success;
-							echo '</div>';
 						}
 					}
 				}


### PR DESCRIPTION
In my tests there were no issue removing these divs. I've removed them to clean up the markup and because while trying to adapt ninja forms to work with Bootstrap these inner divs caused some spacing problems.