### PR TITLE
apply fitlers to NINJA_FORMS_JS_DEBUG

### DIFF
--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -323,7 +323,7 @@ class Ninja_Forms {
 
 		// Ninja Forms debug mode
 		if ( ! defined( 'NINJA_FORMS_JS_DEBUG' ) )
-			define( 'NINJA_FORMS_JS_DEBUG', false );
+			define( 'NINJA_FORMS_JS_DEBUG', apply_filters( 'ninja_forms_js_debug', FALSE ) );
 
 		// Ninja Forms plugin directory
 		if ( ! defined( 'NINJA_FORMS_DIR' ) )


### PR DESCRIPTION
This would allow a custom plugin to filter the value of NINJA_FORMS_JS_DEBUG without worrying about order of constant declaration.

Also avoids cowboy changing the hardcoded value in the main Ninja Forms file.