### PR TITLE
"Today date" field shows different date from WordPress. Resolve #730

### DIFF
--- a/includes/display/fields/clear-complete.php
+++ b/includes/display/fields/clear-complete.php
@@ -75,7 +75,7 @@ function nf_clear_complete( $form_id ) {
 				} else {
 					$date_format = 'm/d/Y';
 				}
-				$default_value = date( $date_format, strtotime( 'now' ) );
+				$default_value = date( $date_format, current_time( 'timestamp' ) );
 				break;
 		}
 

--- a/includes/display/processing/class-display-loading.php
+++ b/includes/display/processing/class-display-loading.php
@@ -196,7 +196,7 @@ class Ninja_Forms_Loading {
 					} else {
 						$date_format = 'm/d/Y';
 					}
-					$default_value = date( $date_format, strtotime( 'now' ) );
+					$default_value = date( $date_format, current_time( 'timestamp' ) );
 					break;
 				default:
 					if ( 'querystring' == $default_value_type ) {


### PR DESCRIPTION
Set  `$default_value`  using  wordpress `current_time( 'timestamp' )` instead `strtotime( 'now' )`