### PR TITLE
custom notification triggers

### DIFF
--- a/classes/notification.php
+++ b/classes/notification.php
@@ -167,4 +167,15 @@ class NF_Notification
 		return Ninja_Forms()->notification_types[ $type ]->name;
 	}
 
+	/**
+	 * Get our notification processing type
+	 * 
+	 * @access public
+	 * @since 3.0
+	 * @return string $processing_type
+	 */
+	public function processing_type() {
+		$type = $this->type;
+		return isset( Ninja_Forms()->notification_types[ $type ]->processing_type ) ? Ninja_Forms()->notification_types[ $type ]->processing_type : 'default';
+	}
 }

--- a/classes/notifications.php
+++ b/classes/notifications.php
@@ -530,7 +530,7 @@ class NF_Notifications
 		if ( is_array( $notifications ) ) {
 			foreach ( $notifications as $id ) {
 				do_action( 'nf_notification_before_process', $id );
-				if ( Ninja_Forms()->notification( $id )->active ) {
+				if ( 'default' == Ninja_Forms()->notification( $id )->processing_type() && Ninja_Forms()->notification( $id )->active ) {
 					Ninja_Forms()->notification( $id )->process();
 				}
 			}


### PR DESCRIPTION
allow notifications to skip processing on default form submission. for #458. No idea, if this is the best approach, but it does allow the the PayPal IPN notification I am working on to not be emailed when the form is submitted. Then it can be called by a custom trigger when the IPN is confirmed.