### PR TITLE
apply post_updated_messages filter on submissions post type only

### DIFF
--- a/classes/subs-cpt.php
+++ b/classes/subs-cpt.php
@@ -636,23 +636,24 @@ class NF_Subs_CPT {
 	function post_updated_messages( $messages ) {
 
 		global $post, $post_ID;
-		$post_type = get_post_type( $post_ID );
+		$post_type = 'nf_sub';
 
 		$obj = get_post_type_object( $post_type );
 		$singular = $obj->labels->singular_name;
 
 		$messages[$post_type] = array(
-			0 => '', // Unused. Messages start at index 1.
-			1 => $singular . ' ' . __( 'updated', 'ninja-forms' ) . '.',
-			2 => 'Custom field updated.',
-			3 => 'Custom field deleted.',
-			4 => $singular.' updated.',
-			5 => isset($_GET['revision']) ? sprintf( $singular.' restored to revision from %s', wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
-			6 => sprintf( $singular.' published. <a href="%s">View '.strtolower($singular).'</a>', esc_url( get_permalink($post_ID) ) ),
-			7 => 'Page saved.',
-			8 => sprintf( $singular.' submitted. <a target="_blank" href="%s">Preview '.strtolower($singular).'</a>', esc_url( add_query_arg( 'preview', 'true', get_permalink($post_ID) ) ) ),
-			9 => sprintf( $singular.' scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview '.strtolower($singular).'</a>', date_i18n( 'M j, Y @ G:i', strtotime( $post->post_date ) ), esc_url( get_permalink($post_ID) ) ),
-			10 => sprintf( $singular.' draft updated. <a target="_blank" href="%s">Preview '.strtolower($singular).'</a>', esc_url( add_query_arg( 'preview', 'true', get_permalink($post_ID) ) ) ),
+			0 => 	'', // Unused. Messages start at index 1.
+	 		1 => 	sprintf( __( '%s updated.', 'ninja-forms' ), $singular ) . $view_post_link_html,
+	 		2 => 	__( 'Custom field updated.' ),
+	 		3 => 	__( 'Custom field deleted.' ),
+	 		4 => 	sprintf( __( '%s updated.', 'ninja-forms' ), $singular ),
+			/* translators: %s: date and time of the revision */
+	 		5 => 	isset($_GET['revision']) ? sprintf( __( '%1$s restored to revision from %2$s.' ), $singular, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+	 		6 => 	sprintf( __( '%s published.', 'ninja-forms' ), $singular ) . $view_post_link_html,
+	 		7 => 	sprintf( __( '%s saved.', 'ninja-forms' ), $singular ),
+	 		8 => 	sprintf( __( '%1$s submitted. <a href="%2$s" target="_blank">Preview %3$s</a>', 'ninja-forms' ), $singular, esc_url( add_query_arg( 'preview', 'true', get_permalink($post_ID) ) ), $singular ),
+	 		9 => 	sprintf( __( '%1$s scheduled for: <strong>%2$s</strong>. <a href="%3$s" target="_blank">Preview %4$s</a>', 'ninja-forms' ), $singular, date_i18n( get_option( 'data_format' ) . ' ' . get_option( 'time_format' ), strtotime( $post->post_date ) ), esc_url( get_permalink($post_ID ) ), $singular ),
+			10 => 	sprintf( __( '%1$s draft updated. <a href="%2$s" target="_blank">Preview %3$s</a>', 'ninja-forms' ), $singular, esc_url( add_query_arg( 'preview', 'true', get_permalink($post_ID) ) ), $singular ),
 		);
 
 		return $messages;


### PR DESCRIPTION
Related to https://github.com/wpninjas/ninja-forms/issues/924

* Apply custom post update messages only to the submission post type.
* Make custom submission update messages translatable.