### PR TITLE
making #960 more specific

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -241,7 +241,14 @@ function nf_wp_kses_post_deep( $value ){
 
 	if( ! is_array( $value ) ) {
 
-		while (stripos($value, 'script') || stripos($value, '</textarea>') || stripos($value, 'textarea>') || stripos($value, '"&gt;') || stripos($value, '">') || stripos($value, "'&gt;") || stripos($value, "'>")) {
+		while (
+            stripos($value, 'script') ||
+            ( stripos($value, 'script') && ( stripos($value, '"&gt;') || stripos($value, '">') || stripos($value, "'&gt;") || stripos($value, "'>") ) ) ||
+            stripos($value, '</textarea>') ||
+            ( stripos($value, '</textarea>') && ( stripos($value, '"&gt;') || stripos($value, '">') || stripos($value, "'&gt;") || stripos($value, "'>") ) ) ||
+            stripos($value, 'textarea>') ||
+            ( stripos($value, 'textarea>') && ( stripos($value, '"&gt;') || stripos($value, '">') || stripos($value, "'&gt;") || stripos($value, "'>") ) )
+		) {
 
 			$value = str_ireplace('script', '', $value);
 			$value = str_ireplace('</textarea>', '', $value);


### PR DESCRIPTION
The XSS fix is breaking HTML in other places. The `stripos()` checks need to be more specific to XSS vulnerabilities.