### PR TITLE
process not_logged_in_msg setting with do_shortcode

### DIFF
--- a/includes/display/form/not-logged-in.php
+++ b/includes/display/form/not-logged-in.php
@@ -9,7 +9,8 @@
 function nf_not_logged_in_msg( $form_id ) {
 	$not_logged_in = Ninja_Forms()->form( $form_id )->get_setting( 'logged_in' );
 	if ( ! is_user_logged_in() && 1 == $not_logged_in ) {
-		echo Ninja_Forms()->form( $form_id )->get_setting( 'not_logged_in_msg' );
+		$not_logged_in_msg = Ninja_Forms()->form( $form_id )->get_setting( 'not_logged_in_msg' );
+		echo do_shortcode( $not_logged_in_msg );
 	}
 }
 


### PR DESCRIPTION
Wrap the `not_logged_in_msg` setting in the WordPress `do_shortcode` .