### PR TITLE
Fix whitescreen on system status page

### DIFF
--- a/includes/Admin/Menus/SystemStatus.php
+++ b/includes/Admin/Menus/SystemStatus.php
@@ -48,7 +48,7 @@ final class NF_Admin_Menus_SystemStatus extends NF_Abstracts_Submenu
 
          //WPLANG
          if ( defined( 'WPLANG' ) && WPLANG ) {
-            $lang = WPLANG();
+            $lang = WPLANG;
          } else {
             $lang = __( 'Default', 'ninja-forms' );
          }


### PR DESCRIPTION
The "Get Help" page whitescreens trying to call WPLANG as a function, instead of accessing the defined value.