### PR TITLE
Fix a fatal error in the NF_AddonChecker class

### DIFF
--- a/lib/NF_AddonChecker.php
+++ b/lib/NF_AddonChecker.php
@@ -10,6 +10,12 @@ final class NF_AddonChecker
 
     public function check_plugins()
     {
+        if ( ! function_exists( 'get_plugins' ) ) {
+
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        }
+
         $plugins = get_plugins();
 
         foreach( $plugins as $plugin => $data ){


### PR DESCRIPTION
```
Fatal error: Call to undefined function get_plugins() in wp-content/plugins/ninja-forms/lib/NF_AddonChecker.php on line 13
```

This PR requires `wp-admin/includes/plugin.php` before attempting to call `get_plugins()` in the `NF_AddonChecker` class constructor.

/cc @kjohnson @kstover @jonathanbardo