### PR TITLE
Translations didn't work anymore in deprecated mode

### DIFF
--- a/deprecated/ninja-forms.php
+++ b/deprecated/ninja-forms.php
@@ -617,7 +617,7 @@ class Ninja_Forms {
         load_textdomain( $textdomain, $wp_lang_dir );
 
         /** Translations: Secondly, look in plugin's "lang" folder = default */
-        $plugin_dir = basename( dirname( __FILE__ ) );
+        $plugin_dir = trailingslashit( basename( dirname( dirname( __FILE__ ) ) ) ) . basename( dirname( __FILE__ ) );
         $lang_dir = apply_filters( 'ninja_forms_lang_dir', $plugin_dir . '/lang/' );
         load_plugin_textdomain( $textdomain, FALSE, $lang_dir );
     }


### PR DESCRIPTION
I added the parent directory to the $lang_dir so the correct directory for translation files is `ninja-forms/deprecated/lang/` instead of just `deprecated/lang/`