### PR TITLE
Change the Time Zone that displays on the 3.0 System Status page

### DIFF
--- a/includes/Admin/Menus/SystemStatus.php
+++ b/includes/Admin/Menus/SystemStatus.php
@@ -69,12 +69,7 @@ final class NF_Admin_Menus_SystemStatus extends NF_Abstracts_Submenu
 
         //Time Zone Check
         //TODO: May need refactored
-        $default_timezone = date_default_timezone_get();
-        if ( 'UTC' !== $default_timezone ) {
-            $default_timezone = sprintf( __( 'Default timezone is %s - it should be UTC', 'ninja-forms' ), $default_timezone );
-        } else {
-            $default_timezone =  sprintf( __( 'Default timezone is %s', 'ninja-forms' ), $default_timezone );
-        }
+        $default_timezone = get_option( 'timezone_string' );
 
         //Check for active plugins
         $active_plugins = (array) get_option( 'active_plugins', array() );


### PR DESCRIPTION
I changed the System Status page in 3.0 to use the WordPress time zone instead of UTC.
Closes #1404 

Replication steps: go to the system status page in 3.0 and view the default timezone.