### PR TITLE
Improved assets related tasks on Gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,10 @@
  * Rename and Minify JavaScript... and more (later).
  *
  * Install Command:
- * npm install gulp gulp-rename gulp-uglify
+ * npm install
+ *
+ * Running Command:
+ * npm run gulp
  */
 
 var gulp   = require('gulp');
@@ -14,8 +17,16 @@ var requirejsOptimize = require('gulp-requirejs-optimize');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
+var postcss = require('gulp-postcss');
+var autoprefixer = require('autoprefixer');
 
-gulp.task('js', function () {
+function getPostCssProcessors() {
+    return [
+        autoprefixer({browsers: ['last 2 versions']}),
+    ];
+}
+
+gulp.task('js:builder', function(){
     gulp.src('assets/js/builder/main.js')
     .pipe(sourcemaps.init())
     .pipe(requirejsOptimize(function(file) {
@@ -31,7 +42,9 @@ gulp.task('js', function () {
     .pipe(rename('builder.js'))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/js/min/'));
+});
 
+gulp.task('js:frontend', function(){
     gulp.src('assets/js/front-end/main.js')
     .pipe(sourcemaps.init())
     .pipe(requirejsOptimize(function(file) {
@@ -49,54 +62,66 @@ gulp.task('js', function () {
     .pipe(gulp.dest('assets/js/min/'));
 });
 
-gulp.task('sass', function () {
+gulp.task('css:builder', function(){
     gulp.src('assets/scss/admin/builder.scss')
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
-    .pipe(autoprefixer())
+    .pipe(postcss(getPostCssProcessors()))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/css'));
+});
 
+
+gulp.task('css:display-structure', function(){
     gulp.src('assets/scss/front-end/display-structure.scss')
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
-    .pipe(autoprefixer())
+    .pipe(postcss(getPostCssProcessors()))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/css'));
+});
 
+gulp.task('css:display-opinions', function(){
     gulp.src('assets/scss/front-end/display-opinions.scss')
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
-    .pipe(autoprefixer())
+    .pipe(postcss(getPostCssProcessors()))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/css'));
+});
 
+gulp.task('css:display-opinions-light', function(){
     gulp.src('assets/scss/front-end/display-opinions-light.scss')
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
-    .pipe(autoprefixer())
+    .pipe(postcss(getPostCssProcessors()))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/css'));
+});
 
+gulp.task('css:display-opinions-dark', function(){
     gulp.src('assets/scss/front-end/display-opinions-dark.scss')
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
-    .pipe(autoprefixer())
+    .pipe(postcss(getPostCssProcessors()))
     .pipe(sourcemaps.write('/'))
     .pipe(gulp.dest('assets/css'));
 });
 
 // Watch Files For Changes
 gulp.task('watch', function() {
-    gulp.watch('assets/js/builder/**/*.js', ['js']);
-    gulp.watch('assets/js/front-end/**/*.js', ['js']);
-    gulp.watch('assets/scss/**/*.scss', ['sass']);
+    gulp.watch('assets/js/builder/**/*.js', ['js:builder']);
+    gulp.watch('assets/js/front-end/**/*.js', ['js:frontend']);
+
+    gulp.watch('assets/scss/**/*.scss', ['css']);
 });
 
-gulp.task('build', ['js', 'sass']);
+gulp.task('js', ['js:builder', 'js:frontend']);
+gulp.task('css', [ 'css:builder', 'css:display-structure', 'css:display-opinions', 'css:display-opinions-light', 'css:display-opinions-dark']);
+
+gulp.task('build', ['js', 'css']);
 // Default Task
 gulp.task('default', ['build', 'watch']);
-
 
 function swallowError (error) {
     //If you want details of the error in the console

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,8 +93,10 @@ gulp.task('watch', function() {
     gulp.watch('assets/scss/**/*.scss', ['sass']);
 });
 
+gulp.task('build', ['js', 'sass']);
 // Default Task
-gulp.task('default', ['js', 'sass', 'watch']);
+gulp.task('default', ['build', 'watch']);
+
 
 function swallowError (error) {
     //If you want details of the error in the console

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "gulp": "gulp"
   },
   "dependencies": {
+    "autoprefixer": "^6.3.6",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-postcss": "^6.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-requirejs-optimize": "^0.3.2",
     "gulp-sass": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ninja-forms",
   "version": "1.0.0",
+  "scripts": {
+    "gulp": "gulp"
+  },
   "dependencies": {
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",


### PR DESCRIPTION
This PR contains two improvements:

- I added the ability to only compile css/js without continuing to watch
- I added the ability to run gulp without having to install gulp globally (in order to install gulp globally you need to be admin/root).
- I've removed the old gulp-autoprefixer and added the post-css & autoprefixer tasks for css (it makes more sense to be this way because will allow later on adding other post processors);
- I've also splitted the JS tasks into their own tasks, for couple of reasons:
  1. It comply better with the gulp philosophy (one task = one responsability)
  - It _should_ be faster to compile JS (i.e. If you change something on the builder JS it make no sense to build the front end task)
- I've splitted the CSS tasks into their own tasks, but this can't be ran separately because there are a lot of cross-dependencies between sass files. The sass task is fast anyway so no need to concern on this...

After this PR, you'll be able to do:

- `npm run gulp` - which work exactly like the old `gulp`; also, the old command is still available;
- `npm run gulp build` - to only compile assets, without continuing watching (useful if you later decide to use a CI service or something like that)