### PR TITLE
Add a filter to force loading of 2.x

### DIFF
--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -24,7 +24,7 @@ if( version_compare( get_option( 'ninja_forms_version', '0.0.0' ), '3', '<' ) ||
     update_option( 'ninja_forms_load_deprecated', TRUE );
 }
 
-if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf2to3' ] ) && ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) ){
+if( apply_filters( 'ninja_forms_force_load_deprecated', false ) || ( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf2to3' ] ) && ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) ) ){
 
     include 'deprecated/ninja-forms.php';
 


### PR DESCRIPTION
#1425 

This PR introduces `ninja_forms_force_load_deprecated` filter with a default value of false. It would allow for forcing loading of 2.X code with `add_filter( 'ninja_forms_force_load_deprecated', '__return_true' );` 