### PR TITLE
Render.php / NF_Display_Render class refactor

### DIFF
--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -48,7 +48,7 @@ final class NF_Display_Render
         }
     }
 
-    public static function form_has_max_submission( $form )
+    private static function form_has_max_submission( $form )
     {
         if( $form->get_setting( 'sub_limit_number' ) ){
             global $wpdb;
@@ -71,6 +71,23 @@ final class NF_Display_Render
         }
     }
 
+    private static function update_settings_filters( $form )
+    {
+        $form_id = $form->get_id();
+
+        $before_form = apply_filters( 'ninja_forms_display_before_form', '', $form_id );
+        $form->update_setting( 'beforeForm', $before_form );
+
+        $before_fields = apply_filters( 'ninja_forms_display_before_fields', '', $form_id );
+        $form->update_setting( 'beforeFields', $before_fields );
+
+        $after_fields = apply_filters( 'ninja_forms_display_after_fields', '', $form_id );
+        $form->update_setting( 'afterFields', $after_fields );
+
+        $after_form = apply_filters( 'ninja_forms_display_after_form', '', $form_id );
+        $form->update_setting( 'afterForm', $after_form );
+    }
+
 
 
 
@@ -87,17 +104,7 @@ final class NF_Display_Render
             return;
         }
 
-        $before_form = apply_filters( 'ninja_forms_display_before_form', '', $form_id );
-        $form->update_setting( 'beforeForm', $before_form );
-
-        $before_fields = apply_filters( 'ninja_forms_display_before_fields', '', $form_id );
-        $form->update_setting( 'beforeFields', $before_fields );
-
-        $after_fields = apply_filters( 'ninja_forms_display_after_fields', '', $form_id );
-        $form->update_setting( 'afterFields', $after_fields );
-
-        $after_form = apply_filters( 'ninja_forms_display_after_form', '', $form_id );
-        $form->update_setting( 'afterForm', $after_form );
+        self::update_settings_filters( $form );
 
         $form_fields = Ninja_Forms()->form( $form_id )->get_fields();
 

--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -51,14 +51,18 @@ final class NF_Display_Render
     public static function form_has_max_submission( $form )
     {
         if( $form->get_setting( 'sub_limit_number' ) ){
-            // $subs = Ninja_Forms()->form( $form_id )->get_subs();
-            // TODO: Optimize Query
             global $wpdb;
-            $count = 0;
-            $subs = $wpdb->get_results( "SELECT post_id FROM wp_postmeta WHERE `meta_key` = '_form_id' AND `meta_value` = $form_id" );
-            foreach( $subs as $sub ){
-                if( 'publish' == get_post_status( $sub->post_id ) ) $count++;
-            }
+
+            $prepared = $wpdb->prepare( "SELECT COUNT(*) as total, post_id, ID
+                FROM {$wpdb->prefix}postmeta meta,
+                  {$wpdb->prefix}posts posts
+                 WHERE
+                 `post_id` = `ID` AND
+                 `post_status` = 'publish' AND
+                 `meta_key` = '_form_id' AND
+                 `meta_value` = %d", $form->get_id() );
+
+            $count =  $wpdb->get_var($prepared);
 
             if( $count >= $form->get_setting( 'sub_limit_number' ) ) {
                 echo $form->get_setting( 'sub_limit_msg' );

--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -88,6 +88,23 @@ final class NF_Display_Render
         $form->update_setting( 'afterForm', $after_form );
     }
 
+    private static function update_field_siblings( $field, $sibling )
+    {
+        // ninja_forms_display_before_field_type_
+        // ninja_forms_display_before_field_key_
+        // ninja_forms_display_after_field_type_
+        // ninja_forms_display_after_field_key_
+        $display_before = apply_filters( "ninja_forms_display_{$sibling}_field_type_" . $field->get_setting( 'type' ), '' );
+        $display_before = apply_filters( "ninja_forms_display_{$sibling}_field_key_" . $field->get_setting( 'key' ), $display_before );
+
+        return $display_before;
+    }
+
+    public static function has_default_label_position( $settings )
+    {
+        return ! isset( $settings[ 'label_pos' ] ) || 'default' == $settings[ 'label_pos' ];
+    }
+
 
 
 
@@ -133,16 +150,13 @@ final class NF_Display_Render
                 $field->update_setting('id', $field->get_id());
 
                 /*
-                 * TODO: For backwards compatibility, run the original action, get contents from the output buffer, and return the contents through the filter. Also display a PHP Notice for a deprecate filter.
+                 * TODO: For backwards compatibility, run the original action, get contents from the output buffer,
+                 * and return the contents through the filter. Also display a PHP Notice for a deprecate filter.
                  */
 
-                $display_before = apply_filters( 'ninja_forms_display_before_field_type_' . $field->get_setting( 'type' ), '' );
-                $display_before = apply_filters( 'ninja_forms_display_before_field_key_' . $field->get_setting( 'key' ), $display_before );
-                $field->update_setting( 'beforeField', $display_before );
 
-                $display_after = apply_filters( 'ninja_forms_display_after_field_type_' . $field->get_setting( 'type' ), '' );
-                $display_after = apply_filters( 'ninja_forms_display_after_field_key_' . $field->get_setting( 'key' ), $display_after );
-                $field->update_setting( 'afterField', $display_after );
+                $field->update_setting( 'beforeField', self::update_field_siblings($field, 'before') );
+                $field->update_setting( 'afterField', self::update_field_siblings($field, 'after') );
 
                 $templates = $field_class->get_templates();
 
@@ -160,7 +174,7 @@ final class NF_Display_Render
                     if (is_numeric($setting)) $settings[$key] = floatval($setting);
                 }
 
-                if( ! isset( $settings[ 'label_pos' ] ) || 'default' == $settings[ 'label_pos' ] ){
+                if( self::has_default_label_position( $settings ) ){
                     $settings[ 'label_pos' ] = $form->get_setting( 'default_label_pos' );
                 }
 

--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -26,12 +26,15 @@ final class NF_Display_Render
 
     protected static $use_test_values = FALSE;
 
-    public static function localize( $form_id )
+    private static function user_can_display_test_values()
     {
-        $capability = apply_filters( 'ninja_forms_display_test_values_capabilities', 'read' );
-        if( isset( $_GET[ 'ninja_forms_test_values' ] ) && current_user_can( $capability ) ){
-            self::$use_test_values = TRUE;
-        }
+        $capability = apply_filters( 'ninja_forms_display_test_values_capabilities', 'read' ) ;
+        return isset( $_GET[ 'ninja_forms_test_values' ] ) && current_user_can( $capability );
+    }
+
+    public static function render( $form_id )
+    {
+        self::$use_test_values =  self::user_can_display_test_values() ;
 
         if( ! has_action( 'wp_footer', 'NF_Display_Render::output_templates', 9999 ) ){
             add_action( 'wp_footer', 'NF_Display_Render::output_templates', 9999 );
@@ -208,14 +211,17 @@ final class NF_Display_Render
 
         <?php
         self::enqueue_scripts( $form_id );
+
+    }
+
+    public static function localize( $form_id )
+    {
+        self::render( $form_id );
     }
 
     public static function localize_preview( $form_id )
     {
-        $capability = apply_filters( 'ninja_forms_display_test_values_capabilities', 'read' );
-        if( isset( $_GET[ 'ninja_forms_test_values' ] ) && current_user_can( $capability ) ){
-            self::$use_test_values = TRUE;
-        }
+        self::$use_test_values = self::user_can_display_test_values() ;
 
         add_action( 'wp_footer', 'NF_Display_Render::output_templates', 9999 );
 

--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -145,6 +145,25 @@ final class NF_Display_Render
         }
     }
 
+    protected static function parse_currency_markers( $price )
+    {
+        // TODO: Does the currency marker need to stripped here?
+        $price = str_replace( array( '$', '£', '€' ), '', $price);
+        $price = str_replace( Ninja_Forms()->get_setting( 'currency_symbol' ), '', $price);
+        $price = number_format($price, 2);
+
+        return $price;
+    }
+
+    protected static function get_shipping_cost( $shipping_cost )
+    {
+        return self::parse_currency_markers($shipping_cost);
+    }
+
+    protected static function get_product_price( $product_price )
+    {
+        return self::parse_currency_markers($product_price);
+    }
 
 
 
@@ -220,17 +239,13 @@ final class NF_Display_Render
                     $settings['value'] = self::get_default_value( $settings, $field_type );
                 }
 
+
+
                 // TODO: Find a better way to do this.
                 if ('shipping' == $settings['type']) {
-                    // TODO: Does the currency marker need to stripped here?
-                    $settings['shipping_cost'] = str_replace( array( '$', '£', '€' ), '', $settings['shipping_cost']);
-                    $settings['shipping_cost'] = str_replace( Ninja_Forms()->get_setting( 'currency_symbol' ), '', $settings['shipping_cost']);
-                    $settings['shipping_cost'] = number_format($settings['shipping_cost'], 2);
+                    $settings['shipping_cost'] = self::get_shipping_cost( $settings['$shipping_cost'] );
                 } elseif ('product' == $settings['type']) {
-                    // TODO: Does the currency marker need to stripped here?
-                    $settings['product_price'] = str_replace( array( '$', '£', '€' ), '', $settings['product_price']);
-                    $settings['product_price'] = str_replace( Ninja_Forms()->get_setting( 'currency_symbol' ), '', $settings['product_price']);
-                    $settings['product_price'] = number_format($settings['product_price'], 2);
+                    $settings['product_price'] = self::get_product_price( $settings['product_price'] );
                 } elseif ('total' == $settings['type'] && isset($settings['value'])) {
                     $settings['value'] = number_format($settings['value'], 2);
                 }


### PR DESCRIPTION
I'm doing some refactorings on this class because it have some huge methods and some code duplication.

For some reasons, the display method is called... localize. Any particular reasons on that? Or i'm free to rename the method (and leave the old name in place, for compatibility reasons)?
