### PR TITLE
Move menu capability filter to register method.

### DIFF
--- a/includes/Abstracts/Menu.php
+++ b/includes/Abstracts/Menu.php
@@ -69,8 +69,6 @@ abstract class NF_Abstracts_Menu
             $this->menu_slug = strtolower( preg_replace( '/[^A-Za-z0-9-]+/', '-', $this->menu_title ) );
         }
 
-        $this->capability = apply_filters( 'menu_' . $this->menu_slug . '_capability', $this->capability );
-
         add_action( 'admin_menu', array( $this, 'register' ) );
     }
 
@@ -82,7 +80,7 @@ abstract class NF_Abstracts_Menu
         add_menu_page(
             $this->page_title,
             $this->menu_title,
-            $this->capability,
+            apply_filters( 'menu_' . $this->menu_slug . '_capability', $this->capability ),
             $this->menu_slug,
             array( $this, $this->function ),
             $this->icon_url,

--- a/includes/Abstracts/Menu.php
+++ b/includes/Abstracts/Menu.php
@@ -80,7 +80,7 @@ abstract class NF_Abstracts_Menu
         add_menu_page(
             $this->page_title,
             $this->menu_title,
-            apply_filters( 'menu_' . $this->menu_slug . '_capability', $this->capability ),
+            apply_filters( 'ninja_forms_menu_' . $this->menu_slug . '_capability', $this->capability ),
             $this->menu_slug,
             array( $this, $this->function ),
             $this->icon_url,

--- a/includes/Abstracts/Submenu.php
+++ b/includes/Abstracts/Submenu.php
@@ -64,8 +64,6 @@ abstract class NF_Abstracts_Submenu
             $this->menu_slug = 'nf-' . strtolower( preg_replace( '/[^A-Za-z0-9-]+/', '-', $this->menu_title ) );
         }
 
-        $this->capability = apply_filters( 'submenu_' . $this->menu_slug . '_capability', $this->capability );
-
         add_action( 'admin_menu', array( $this, 'register' ), $this->priority );
     }
 
@@ -80,7 +78,7 @@ abstract class NF_Abstracts_Submenu
             $this->parent_slug,
             $this->page_title,
             $this->menu_title,
-            $this->capability,
+            apply_filters( 'submenu_' . $this->menu_slug . '_capability', $this->capability ),
             $this->menu_slug,
             $function
         );

--- a/includes/Abstracts/Submenu.php
+++ b/includes/Abstracts/Submenu.php
@@ -78,7 +78,7 @@ abstract class NF_Abstracts_Submenu
             $this->parent_slug,
             $this->page_title,
             $this->menu_title,
-            apply_filters( 'submenu_' . $this->menu_slug . '_capability', $this->capability ),
+            apply_filters( 'ninja_forms_submenu_' . $this->menu_slug . '_capability', $this->capability ),
             $this->menu_slug,
             $function
         );


### PR DESCRIPTION
The capability filter was running in the parent class constructor, before any other plugins had a change to add filters.