### PR TITLE
Fix Textarea Encoding on Saved Submission Load

### DIFF
--- a/deprecated/includes/fields/textarea.php
+++ b/deprecated/includes/fields/textarea.php
@@ -98,7 +98,7 @@ function ninja_forms_field_textarea_display( $field_id, $data, $form_id = '' ){
 
 	$field_class = ninja_forms_get_field_class( $field_id, $form_id );
 
-	$default_value = filter_var( $default_value, FILTER_SANITIZE_STRING );
+	$default_value = filter_var( $default_value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
 	$default_value = filter_var( $default_value, FILTER_SANITIZE_SPECIAL_CHARS );
 
 	if($textarea_rte == 1){


### PR DESCRIPTION
When loading a saved submission, single and double quotes are encoded into HTML entities. 

This modifies the filter_var statement responsible to exclude quotes from the sanitization.