### PR TITLE
Copy list options label to value when not set.

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -468,6 +468,11 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
                 $field[ 'options' ] = $field[ 'list' ][ 'options' ];
                 unset( $field[ 'list' ][ 'options' ] );
             }
+
+            foreach( $field[ 'options' ] as &$option ){
+                if( isset( $option[ 'value' ] ) && $option[ 'value' ] ) continue;
+                $option[ 'value' ] = $option[ 'label' ];
+            }
         }
 
         // Convert `textbox` to other field types


### PR DESCRIPTION
List options without set values should assume the label as the value. This was missed during conversion. If the value is not set, then make the value the same as the label.