### PR TITLE
Swap JSON encoding for serialization of form export.

### DIFF
--- a/includes/Abstracts/ModelFactory.php
+++ b/includes/Abstracts/ModelFactory.php
@@ -114,7 +114,9 @@ class NF_Abstracts_ModelFactory
      */
     public function import_form( $import, $id = FALSE, $is_conversion = FALSE )
     {
-        $import = maybe_unserialize( $import );
+        if( ! is_array( $import ) ){
+            $import = json_decode( $import );
+        }
         return NF_Database_Models_Form::import( $import, $id, $is_conversion );
     }
 

--- a/includes/Admin/Menus/ImportExport.php
+++ b/includes/Admin/Menus/ImportExport.php
@@ -29,10 +29,17 @@ final class NF_Admin_Menus_ImportExport extends NF_Abstracts_Submenu
 
         $import = file_get_contents( $_FILES[ 'nf_import_form' ][ 'tmp_name' ] );
 
-        $data = unserialize( base64_decode( $import ) );
+        $data = json_decode( $import, true );
 
-        if( ! $data ) {
-            $data = unserialize( $import );
+        if( json_last_error() ) {
+            $data = maybe_unserialize( $import );
+        }
+
+        if( ! is_array( $data ) ){
+            wp_die(
+                __( 'There uploaded file is not a valid form.', 'ninja-forms' ),
+                __( 'Invalid Form Upload.', 'ninja-forms' )
+            );
         }
 
         Ninja_Forms()->form()->import_form( $data );

--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -182,12 +182,12 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             $filename = apply_filters( 'ninja_forms_form_export_filename', 'nf_form_' . $today );
             $filename = $filename . ".nff";
 
-            header( 'Content-type: application/nff');
+            header( 'Content-type: application/json');
             header( 'Content-Disposition: attachment; filename="'.$filename .'"' );
             header( 'Pragma: no-cache');
             header( 'Expires: 0' );
-            echo apply_filters( 'ninja_forms_form_export_bom',"\xEF\xBB\xBF" ) ; // Byte Order Mark
-            echo base64_encode( maybe_serialize( $export ) );
+//            echo apply_filters( 'ninja_forms_form_export_bom',"\xEF\xBB\xBF" ) ; // Byte Order Mark
+            echo json_encode( $export );
 
             die();
         }


### PR DESCRIPTION
This replaces the old method of serializing form exports with a more modern use of a JSON string.