### PR TITLE
Use a more targeted string comparison to check for NF add-on plugins. #1640.

### DIFF
--- a/lib/NF_AddonChecker.php
+++ b/lib/NF_AddonChecker.php
@@ -20,7 +20,7 @@ final class NF_AddonChecker
 
         foreach( $plugins as $plugin => $data ){
 
-            if( 'ninja-forms/ninja-forms.php' != $plugin && 0 === strpos( $plugin, 'ninja-forms' ) && version_compare( $data[ 'Version' ], '3', '<' ) ){
+            if( 'ninja-forms/ninja-forms.php' != $plugin && 0 === strncmp( $plugin, 'ninja-forms-', 12 ) && version_compare( $data[ 'Version' ], '3', '<' ) ){
 
                 if( ! is_plugin_active( $plugin ) ) continue;
 


### PR DESCRIPTION
Switches the plugin slug check present in `NF_AddonChecker::check_plugins()` to a string comparison of the beginning of the plugin slug, checking only for a prefix `ninja-forms-`, instead of a substr of `ninja-forms` anywhere within the plugin slug.

#1640.