### PR TITLE
plugins_loaded is too early to use current_user_can

### DIFF
--- a/includes/Admin/Menus/ImportExport.php
+++ b/includes/Admin/Menus/ImportExport.php
@@ -8,11 +8,11 @@ final class NF_Admin_Menus_ImportExport extends NF_Abstracts_Submenu
 
     public function __construct()
     {
-        add_action( 'plugins_loaded', array( $this, 'import_form_listener' ) );
-        add_action( 'plugins_loaded', array( $this, 'export_form_listener' ) );
+        add_action( 'init', array( $this, 'import_form_listener' ), 0 );
+        add_action( 'init', array( $this, 'export_form_listener' ), 0 );
 
-        add_action( 'plugins_loaded', array( $this, 'import_fields_listener' ) );
-        add_action( 'plugins_loaded', array( $this, 'export_fields_listener' ) );
+        add_action( 'init', array( $this, 'import_fields_listener' ), 0 );
+        add_action( 'init', array( $this, 'export_fields_listener' ), 0 );
 
         add_filter( 'ninja_forms_before_import_fields', array( $this, 'import_fields_backwards_compatibility' ) );
 


### PR DESCRIPTION
This is a potentially backwards-compatibility breaking change (though to the best of my very limited knowledge, it's unlikely).

plugins_loaded, while earlier (and perhaps chosen for that reason, assuming better performance) than init, is too early to use the `current_user_can()` functions used in the form listener methods.

By the time `init` runs, `set_current_user` has just run - which means this is the earliest point in the runtime that we can verifiably rely on the user and their capabilities.  Running early on init means that any performance issues should be basically mitigated.

Ran into this because when running Ninja Forms in conjunction with bbPress - bbPress will throw doing_it_wrong() notices that will fill up your log quite fast :)
