### PR TITLE
Adding an empty function for ninja_forms_get_form_by_id() so that sit…

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -289,3 +289,7 @@ function _nf_removed_hooks() {
     }
 }
 
+function ninja_forms_get_form_by_id( $form_id ) {
+    Ninja_Forms::deprecated_notice( $hook, '3.0', null );
+    return array();
+}


### PR DESCRIPTION
…es that utilize the older function do not throw a fatal error. Closes #1927.