### PR TITLE
bypass cache for submission sequence.

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -46,11 +46,15 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
 
     public static function get_next_sub_seq( $form_id )
     {
-        $form = Ninja_Forms()->form( $form_id )->get();
+        global $wpdb;
 
-        $last_seq_num = $form->get_setting( '_seq_num', 1 );
+        // TODO: Leverage form cache.
 
-        $form->update_setting( '_seq_num', $last_seq_num + 1 )->save();
+        $last_seq_num = $wpdb->get_var( $wpdb->prepare(
+            'SELECT value FROM ' . $wpdb->prefix . 'nf3_form_meta WHERE `key` = "_seq_num" AND `parent_id` ="' . $form_id . '"'
+        ));
+
+        $wpdb->update( $wpdb->prefix . 'nf3_form_meta', array( 'value' => $last_seq_num + 1 ), array( 'key' => '_seq_num', 'parent_id' => $form_id ) );
 
         return $last_seq_num;
     }


### PR DESCRIPTION
The submission sequence number was being pulled from the cache, which wasn't being updated.

This will need to be modified again when we update the Models and Cache.