### PR TITLE
Update unknown field creation.

### DIFF
--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -174,7 +174,11 @@ final class NF_Display_Render
                 if( ! is_string( $field_type ) ) continue;
 
                 if( ! isset( Ninja_Forms()->fields[ $field_type ] ) ) {
-                    $field = NF_Fields_Unknown::create( $field );
+                    $unknown_field = NF_Fields_Unknown::create( $field );
+                    $field = array(
+                        'settings' => $unknown_field->get_settings(),
+                        'id' => $unknown_field->get_id()
+                    );
                     $field_type = $field[ 'settings' ][ 'type' ];
                 }
 

--- a/includes/Fields/Unknown.php
+++ b/includes/Fields/Unknown.php
@@ -56,14 +56,34 @@ class NF_Fields_Unknown extends NF_Fields_Hidden
     public static function create( $field )
     {
         $unknown = Ninja_Forms()->form()->field()->get();
-        $unknown->update_settings(array(
-            'id'      => $field->get_id(),
-            'label'   => $field->get_setting( 'label' ),
-            'order'   => $field->get_setting( 'order' ),
-            'key'     => $field->get_setting( 'key' ),
-            'type'    => 'unknown',
-            'message' => sprintf( __( 'Field type "%s" not found.', 'ninja-forms' ), $field->get_setting( 'type' ) )
-        ));
+        if( is_object( $field ) ){
+            $unknown->update_settings(array(
+                'id'      => $field->get_id(),
+                'label'   => $field->get_setting( 'label' ),
+                'order'   => $field->get_setting( 'order' ),
+                'key'     => $field->get_setting( 'key' ),
+                'type'    => 'unknown',
+                'message' => sprintf( __( 'Field type "%s" not found.', 'ninja-forms' ), $field->get_setting( 'type' ) )
+            ));
+        } elseif( isset( $field[ 'settings' ] ) ){
+            $unknown->update_settings(array(
+                'id'      => $field[ 'id' ],
+                'label'   => $field[ 'settings' ][ 'label' ],
+                'order'   => $field[ 'settings' ][ 'order' ],
+                'key'     => $field[ 'settings' ][ 'key' ],
+                'type'    => 'unknown',
+                'message' => sprintf( __( 'Field type "%s" not found.', 'ninja-forms' ), $field[ 'settings' ][ 'type' ] )
+            ));
+        } else {
+            $unknown->update_settings(array(
+                'id'      => $field[ 'id' ],
+                'label'   => $field[ 'label' ],
+                'order'   => $field[ 'order' ],
+                'key'     => $field[ 'key' ],
+                'type'    => 'unknown',
+                'message' => sprintf( __( 'Field type "%s" not found.', 'ninja-forms' ), $field[ 'type' ] )
+            ));
+        }
         return $unknown;
     }
 }


### PR DESCRIPTION
Updated the way `Unknown` fields are created, depending on the incoming data from the field type that cannot be identified.

--

FOR TESTING:

- Create a form
- Change the type of a field to an unknown field type.
- Open form in the builder. Check for errors.
- Open form on the front end. Check for errors.