### PR TITLE
Add random id and explicit rendering function for captchas #1298

### DIFF
--- a/deprecated/includes/fields/recaptcha.php
+++ b/deprecated/includes/fields/recaptcha.php
@@ -17,7 +17,6 @@ function ninja_forms_register_field_recaptcha() {
 		'edit_custom_class' => false,
 		'edit_help' => false,
 		'edit_meta' => false,
-		'sidebar' => 'template_fields',
 		'edit_conditional' => true,
 		'conditional' => array(
 			'action' => array(
@@ -51,15 +50,22 @@ function ninja_forms_field_recaptcha_display( $field_id, $data, $form_id = '' ) 
 	$lang = $settings['recaptcha_lang'];
 	$siteKey = $settings['recaptcha_site_key'];
 	$field_class = ninja_forms_get_field_class( $field_id, $form_id );
+	$rand = wp_rand(0, 99999);
+	wp_enqueue_script(
+		'g-recaptcha',
+		'https://www.google.com/recaptcha/api.js?onload=ninja_forms_grecaptcha_explicit_render&render=explicit&hl='.$lang,
+		['ninja-forms-display'] );
 	if ( !empty( $siteKey ) ) { ?>
-		<input id="ninja_forms_field_<?php echo $field_id;?>" name="ninja_forms_field_<?php echo $field_id;?>" type="hidden" class="<?php echo $field_class;?>" value="" rel="<?php echo $field_id;?>" />
-		<div class="g-recaptcha" data-callback="nf_recaptcha_set_field_value" data-sitekey="<?php echo $siteKey; ?>"></div>
-        <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=<?php echo $lang; ?>"> </script>
+		<input id="ninja_forms_field_<?php echo $rand;?>" name="ninja_forms_field_<?php echo
+		$field_id;?>" type="hidden" class="<?php echo $field_class;?>" value="" rel="<?php echo $field_id;?>"
+		/>
+		<div class="g-recaptcha" data-callback="nf_recaptcha_set_field_value"
+		     data-sitekey="<?php echo $siteKey; ?>"></div>
 		<script type="text/javascript">
-            function nf_recaptcha_set_field_value(inpval){
-            	jQuery("#ninja_forms_field_<?php echo $field_id;?>").val(inpval)
-            }
-            </script>
+			function nf_recaptcha_set_field_value(inpval){
+				jQuery("#ninja_forms_field_<?php echo $rand;?>").val(inpval);
+			}
+		</script>
 		<?php
 	}
 }

--- a/deprecated/js/dev/ninja-forms-display.js
+++ b/deprecated/js/dev/ninja-forms-display.js
@@ -999,3 +999,11 @@ function ninja_forms_var_operator(op) {
         }
     }
 }
+
+function ninja_forms_grecaptcha_explicit_render(){
+	jQuery('.g-recaptcha').each(function(){
+		grecaptcha.render(this, {
+			'sitekey':jQuery(this).data('sitekey')
+		});
+	});
+}


### PR DESCRIPTION

Added new js function for explicit rendering called ninja_forms_grecaptcha_explicit_render() to allow explicit rendering of captchas on a single page. I have only implemented this for plugins below version 3.0 (in the deprecated directory). Also added a unique ID to select each captcha input field on success (for nf_recaptcha_set_field_value()).

* Enqueue google recaptcha script with the ninja-forms-display dependency
* Added function for explicit rendering of captcha fields
* Changed ID of recaptcha hidden field to have a random number instead of the field ID (we need unique field ID's for explicit render)
* Removed duplicate array key 'sidebar'