### PR TITLE
Closes Issue#2186

### DIFF
--- a/includes/Admin/AllFormsTable.php
+++ b/includes/Admin/AllFormsTable.php
@@ -21,11 +21,6 @@ class NF_Admin_AllFormsTable extends WP_List_Table
             'plural'   => __( 'Forms', 'ninja-forms' ), //plural name of the listed records
             'ajax'     => false //should this table support ajax?
         ) );
-
-        wp_enqueue_script( 'nf-all-forms', Ninja_Forms::$url . 'assets/js/all-forms.js' );
-        wp_localize_script( 'nf-all-forms', 'nfi18n', array(
-            'confirm_delete' => __( 'Really Delete This Form? This will remove all fields and submission data. Recovery is not possible.', 'ninja-forms' ),
-        ) );
     }
 
     public function no_items() {
@@ -39,6 +34,12 @@ class NF_Admin_AllFormsTable extends WP_List_Table
      */
     public function prepare_items()
     {
+
+        wp_enqueue_script( 'nf-all-forms', Ninja_Forms::$url . 'assets/js/all-forms.js' );
+        wp_localize_script( 'nf-all-forms', 'nfi18n', array(
+            'confirm_delete' => __( 'Really Delete This Form? This will remove all fields and submission data. Recovery is not possible.', 'ninja-forms' ),
+        ) );
+
         $columns = $this->get_columns();
         $hidden = $this->get_hidden_columns();
         $sortable = $this->get_sortable_columns();

--- a/includes/Admin/CPT/DownloadAllSubmissions.php
+++ b/includes/Admin/CPT/DownloadAllSubmissions.php
@@ -139,9 +139,7 @@ class NF_Admin_CPT_DownloadAllSubmissions extends NF_Step_Processing {
             ?>
             <script type="text/javascript">
                 jQuery(document).ready(function() {
-                    jQuery('<option>').val('export').text('<?php _e('Export')?>').appendTo("select[name='action']");
-                    jQuery('<option>').val('export').text('<?php _e('Export')?>').appendTo("select[name='action2']");
-                    <?php
+                     <?php
                     if ( ( isset ( $_POST['action'] ) && $_POST['action'] == 'export' ) || ( isset ( $_POST['action2'] ) && $_POST['action2'] == 'export' ) ) {
                     ?>
                     setInterval(function(){

--- a/includes/Admin/CPT/Submission.php
+++ b/includes/Admin/CPT/Submission.php
@@ -19,7 +19,7 @@ class NF_Admin_CPT_Submission
         add_action( 'admin_print_styles', array( $this, 'enqueue_scripts' ) );
 
         // Filter Post Row Actions
-        add_filter( 'post_row_actions', array( $this, 'post_row_actions' ) );
+        add_filter( 'post_row_actions', array( $this, 'post_row_actions' ), 10, 2 );
 
         // Change our submission columns.
         add_filter( 'manage_nf_sub_posts_columns', array( $this, 'change_columns' ) );
@@ -113,12 +113,16 @@ class NF_Admin_CPT_Submission
         wp_localize_script( 'subs-cpt', 'nf_sub', array( 'form_id' => $form_id ) );
     }
 
-    public function post_row_actions( $actions )
+    public function post_row_actions( $actions, $sub )
     {
         if( $this->cpt_slug == get_post_type() ){
             unset( $actions[ 'view' ] );
             unset( $actions[ 'inline hide-if-no-js' ] );
         }
+
+        $export_url = add_query_arg( array( 'action' => 'export', 'post[]' => $sub->ID ) );
+        $actions[ 'export' ] = sprintf( '<a href="%s">%s</a>', $export_url, __( 'Export', 'ninja-forms' ) );
+
         return $actions;
     }
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -90,8 +90,12 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 
             if( in_array( $field->get_setting( 'type' ), $hidden_field_types ) ) continue;
 
-            // TODO: Add support for 'Admin Labels'
-            $cols[ 'field_' . $field->get_id() ] = $field->get_setting( 'label' );
+            if ( $field->get_setting( 'admin_label' ) ) {
+                $cols[ 'field_' . $field->get_id() ] = $field->get_setting( 'admin_label' );
+            } else {
+                $cols[ 'field_' . $field->get_id() ] = $field->get_setting( 'label' );  
+            }
+            
         }
 
         $cols[ 'sub_date' ] = __( 'Date', 'ninja-forms' );

--- a/includes/Database/Models/Submission.php
+++ b/includes/Database/Models/Submission.php
@@ -305,8 +305,12 @@ final class NF_Database_Models_Submission
         foreach( $fields as $field ){
 
             if( in_array( $field->get_setting( 'type' ), $hidden_field_types ) ) continue;
-
-            $field_labels[ $field->get_id() ] = $field->get_setting( 'label' );
+            if ( $field->get_setting( 'admin_label' ) ) {
+                $field_labels[ $field->get_id() ] = $field->get_setting( 'admin_label' );
+            } else {
+                $field_labels[ $field->get_id() ] = $field->get_setting( 'label' );
+            }
+            
         }
 
 


### PR DESCRIPTION
Removing an extra "Export" bulk action on the submissions screen. 
Making sure that the form deletion warning only shows on the form table.
The submission table and exports should now use admin_label settings if they are present.
Adding an individual export link to submissions table. Closes #2186.