### PR TITLE
issue/1584

### DIFF
--- a/includes/Admin/Menus/Forms.php
+++ b/includes/Admin/Menus/Forms.php
@@ -15,8 +15,8 @@ final class NF_Admin_Menus_Forms extends NF_Abstracts_Menu
         parent::__construct();
 
         if( ! defined( 'DOING_AJAX' ) ) {
-            add_action('admin_init', array($this, 'admin_init'));
-            add_action( 'admin_init', array( 'NF_Admin_AllFormsTable', 'process_bulk_action' ) );
+            add_action('current_screen', array($this, 'admin_init'));
+            add_action( 'current_screen', array( 'NF_Admin_AllFormsTable', 'process_bulk_action' ) );
         }
     }
 


### PR DESCRIPTION
Unbreak the admin_post_($action} hook as recommended by @o1y in https://github.com/wpninjas/ninja-forms/issues/1584#issuecomment-264245151