### PR TITLE
Powered by Ninja Forms

### DIFF
--- a/includes/Fields/Ninja.php
+++ b/includes/Fields/Ninja.php
@@ -1,0 +1,35 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Class NF_Fields_Ninja
+ */
+class NF_Fields_Ninja extends NF_Abstracts_Input
+{
+    protected $_name = 'ninja';
+
+    protected $_type = 'ninja';
+
+    protected $_section = '';
+
+    // protected $_icon = '';
+
+    protected $_templates = 'ninja';
+
+    protected $_settings_only = array( 'classes' );
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->_nicename = __( 'Ninja', 'ninja-forms' );
+        add_filter( 'nf_sub_hidden_field_types', array( $this, 'hide_field_type' ) );
+    }
+
+    function hide_field_type( $field_types )
+    {
+        $field_types[] = $this->_name;
+
+        return $field_types;
+    }
+
+}

--- a/includes/Templates/fields-ninja.html
+++ b/includes/Templates/fields-ninja.html
@@ -1,0 +1,10 @@
+<script id="tmpl-nf-field-ninja" type="text/template">
+    <!-- TODO: Move CSS to stylesheet. -->
+    <style>
+      .nf-field-container.ninja-container .nf-field-label,
+      #ninja_forms_required_items.ninja-container .nf-field-label {
+        display: none;
+      }
+    </style>
+    <div style="text-align: right;">Powered by <a href="https://ninjaforms.com" target="_blank">Ninja Forms<a/>.</div>
+</script>


### PR DESCRIPTION
Adds a new `ninja` field type for displaying a "Powered by Ninja Forms" message.

![poweredbyninjaforms](https://cloud.githubusercontent.com/assets/10858303/21780233/cb4a5fb2-d678-11e6-9716-13aaad9b4ffd.png)
