### PR TITLE
Update MergeTags.php

### DIFF
--- a/includes/Abstracts/MergeTags.php
+++ b/includes/Abstracts/MergeTags.php
@@ -49,8 +49,14 @@ abstract class NF_Abstracts_MergeTags
 
             if( ! isset($merge_tag[ 'callback' ])) continue;
 
-            $replace = ( is_callable( array( $this, $merge_tag[ 'callback' ] ) ) ) ? $this->{$merge_tag[ 'callback' ]}() : '';
-
+            if ( is_callable( array( $this, $merge_tag[ 'callback' ] ) ) ) {
+				$replace = $this->{$merge_tag[ 'callback' ]}();
+			} elseif ( is_callable( $merge_tag[ 'callback' ] ) ) {
+				$replace = $merge_tag[ 'callback' ]();
+			} else {
+				$replace = '';
+			}
+            
             $subject = str_replace( $merge_tag[ 'tag' ], $replace, $subject );
         }
 


### PR DESCRIPTION
Enhanced the callback capability, by allowing to call outside functions, instead of only functions from within the scope.

Explanation: Without this addition there is no way to add own MergeTags via 'ninja_forms_merge_tags_post' inside the /includes/Config/MergeTagsPost.php as this only applied to function within a final class.