### PR TITLE
Prevent Submission IDs from resetting

### DIFF
--- a/includes/AJAX/Controllers/Form.php
+++ b/includes/AJAX/Controllers/Form.php
@@ -37,6 +37,8 @@ class NF_AJAX_Controllers_Form extends NF_Abstracts_Controller
         } else {
             $form = Ninja_Forms()->form($form_data['id'])->get();
         }
+        
+        unset( $form_data[ 'settings' ][ '_seq_num' ] );
 
         $form->update_settings( $form_data[ 'settings' ] )->save();
 


### PR DESCRIPTION
Updated caching to remove _seq_num if it exists from old data. This should prevent the reset of the sequential submission IDs.