### PR TITLE
Remove PHP Warnings on Publish

### DIFF
--- a/includes/Database/FieldsController.php
+++ b/includes/Database/FieldsController.php
@@ -176,13 +176,16 @@ final class NF_Database_FieldsController
     private function insert_field_meta( $field_id, $key, $value )
     {
         static $counter;
+        
+        $value = maybe_serialize( $value );
+        
         $this->db->escape_by_ref( $field_id );
         $this->db->escape_by_ref( $key );
         $this->db->escape_by_ref( $value );
 
-        $value = maybe_serialize( $value );
-
-        if( ! $this->insert_field_meta[ $this->insert_field_meta_chunk ] ) $this->insert_field_meta[ $this->insert_field_meta_chunk ] = '';
+        if( ! isset( $this->insert_field_meta[ insert_field_meta_chunk ] ) || ! $this->insert_field_meta[ $this->insert_field_meta_chunk ] ) {
+            $this->insert_field_meta[ $this->insert_field_meta_chunk ] = '';
+        }
         $this->insert_field_meta[ $this->insert_field_meta_chunk ] .= "('{$field_id}','{$key}','{$value}' ),";
         $counter++;
         if( 0 == $counter % 5000 ) $this->insert_field_meta_chunk++;
@@ -210,7 +213,9 @@ final class NF_Database_FieldsController
         $value = maybe_serialize( $value );
         $this->db->escape_by_ref( $key   );
         $this->db->escape_by_ref( $value );
-        if( ! $this->update_field_meta[ $this->update_field_meta_chunk ] ) $this->update_field_meta[ $this->update_field_meta_chunk ] = '';
+        if( ! isset( $this->update_field_meta[ $this->update_field_meta_chunk ] ) || ! $this->update_field_meta[ $this->update_field_meta_chunk ] ) {
+            $this->update_field_meta[ $this->update_field_meta_chunk ] = '';
+        }
         $this->update_field_meta[ $this->update_field_meta_chunk ] .= " WHEN `parent_id` = '{$field_id}' AND `key` = '{$key}' THEN '{$value}'";
 
         $counter++;


### PR DESCRIPTION
Updated some of the chunking logic in the INSERT and UPDATE sections to remove php warnings, which could be contributing to long publish times.