### PR TITLE
Removed Duplicated Labels from All Submission Exports

### DIFF
--- a/includes/Admin/CPT/DownloadAllSubmissions.php
+++ b/includes/Admin/CPT/DownloadAllSubmissions.php
@@ -88,6 +88,9 @@ class NF_Admin_CPT_DownloadAllSubmissions extends NF_Step_Processing {
                 $sub_ids[] = $result->ID;
             }
             $export .= NF_Database_Models_Submission::export( $this->args['form_id'], $sub_ids, TRUE );
+            if( 1 < $this->step ) {
+                $export = substr( $export, strpos( $export, PHP_EOL ) + 1 );
+            }
 
             fwrite( $myfile, $export );
             fclose( $myfile );


### PR DESCRIPTION
Added a catch to ensure Field Labels are only output once in exports of All Submissions.