### PR TITLE
Rename Custom action to WP Hook

### DIFF
--- a/includes/Actions/Custom.php
+++ b/includes/Actions/Custom.php
@@ -32,7 +32,7 @@ final class NF_Actions_Custom extends NF_Abstracts_Action
     {
         parent::__construct();
 
-        $this->_nicename = __( 'Custom', 'ninja-forms' );
+        $this->_nicename = __( 'WP Hook', 'ninja-forms' );
 
         $settings = Ninja_Forms::config( 'ActionCustomSettings' );
 


### PR DESCRIPTION
Closes #2562.

There is a lot of confusion for developers extending Ninja Forms when they see the "Custom" Action in the builder. This "Custom" Action was built to trigger a WordPress action hook, however it is a one way data transfer and does not  modify the form data (ie this is not for filters).

Instead, I suggest that we rename the action to "WP Hook" to better communicate its purpose.