### PR TITLE
Notice on Submissions page from Anonymous Form Submitters

### DIFF
--- a/includes/Admin/CPT/Submission.php
+++ b/includes/Admin/CPT/Submission.php
@@ -291,7 +291,11 @@ class NF_Admin_CPT_Submission
 
         $status = ucwords( $sub->get_status() );
 
-        $user = apply_filters( 'nf_edit_sub_username', $sub->get_user()->data->user_nicename, $post->post_author );
+        if ($sub->get_user()) {
+            $user = apply_filters('nf_edit_sub_username', $sub->get_user()->data->user_nicename, $post->post_author);
+        } else {
+            $user = 'Anonymous';
+        }
 
         $form_title = $sub->get_form_title();
 

--- a/includes/Admin/CPT/Submission.php
+++ b/includes/Admin/CPT/Submission.php
@@ -134,7 +134,7 @@ class NF_Admin_CPT_Submission
         static $columns;
 
         if( $columns ) return $columns;
-        
+
         $columns = array(
             'cb'    => '<input type="checkbox" />',
             'id' => __( '#', 'ninja-forms' ),
@@ -294,7 +294,7 @@ class NF_Admin_CPT_Submission
         if ($sub->get_user()) {
             $user = apply_filters('nf_edit_sub_username', $sub->get_user()->data->user_nicename, $post->post_author);
         } else {
-            $user = 'Anonymous';
+            $user = __( 'Anonymous', 'ninja-forms' );
         }
 
         $form_title = $sub->get_form_title();

--- a/includes/Database/Models/Submission.php
+++ b/includes/Database/Models/Submission.php
@@ -30,10 +30,12 @@ final class NF_Database_Models_Submission
 
         if( $this->_id ){
             $sub = get_post( $this->_id );
-            $this->_status = $sub->post_status;
-            $this->_user_id = $sub->post_author;
-            $this->_sub_date = $sub->post_date;
-            $this->_mod_date = $sub->post_modified;
+            if ($sub) {
+                $this->_status = $sub->post_status;
+                $this->_user_id = $sub->post_author;
+                $this->_sub_date = $sub->post_date;
+                $this->_mod_date = $sub->post_modified;
+            }
         }
 
         if( $this->_id && ! $this->_form_id ){


### PR DESCRIPTION
When an anonymous user (user not logged into wordpress) submits a form, the submission throws a notice as it attempts to get the nice_name of that user without checking if a user exists.

```
Notice: Trying to get property of non-object in /site/web/app/plugins/ninja-forms/includes/Admin/CPT/Submission.php on line 294

Call Stack
#	Time	Memory	Function	Location
1	0.0020	241496	{main}( )	.../post.php:0
2	0.6544	19826000	include( '/site/web/wp/wp-admin/edit-form-advanced.php' )	.../post.php:173
3	0.9792	26065128	do_meta_boxes( ???, ???, ??? )	.../edit-form-advanced.php:696
4	0.9802	26068496	call_user_func:{/site/web/wp/wp-admin/includes/template.php:1048} ( ???, ???, ??? )	.../template.php:1048
5	0.9802	26068848	NF_Admin_CPT_Submission->info_meta_box( ???, ??? )	.../template.php:1048
```

![submitter_error](https://cloud.githubusercontent.com/assets/361586/24961688/a587d236-1f67-11e7-96d7-978019b95851.png)