### PR TITLE
Fix MailChimp Conflict

### DIFF
--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -48,7 +48,8 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
 
     public function custom_columns( $value, $field )
     {
-        if( 'checkbox' == $field->get_setting( 'type' ) ){
+        if( 'checkbox' == $field->get_setting( 'type' ) ) {
+            if ( 'checked' == $value || 'unchecked' == $value ) return $value;
             $value = ( $value ) ? __( 'checked', 'ninja-forms' ) : __( 'unchecked', 'ninja-forms' );
         }
         return $value;
@@ -81,7 +82,8 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
     }
 
     public function export_value( $value ) {
-        if ( 1 == $value ) {
+        if ( 'checked' == $value || 'unchecked' == $value ) return $value;
+        if ( $value ) {
             return __( 'checked', 'ninja-forms' );
         } else {
             return __( 'unchecked', 'ninja-forms' );

--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -49,7 +49,8 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
     public function custom_columns( $value, $field )
     {
         if( 'checkbox' == $field->get_setting( 'type' ) ) {
-            if ( 'checked' == $value || 'unchecked' == $value ) return $value;
+            if ( __( 'checked', 'ninja-forms' ) == $value ||
+                 __( 'unchecked', 'ninja-forms' ) == $value ) return $value;
             $value = ( $value ) ? __( 'checked', 'ninja-forms' ) : __( 'unchecked', 'ninja-forms' );
         }
         return $value;
@@ -82,7 +83,8 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
     }
 
     public function export_value( $value ) {
-        if ( 'checked' == $value || 'unchecked' == $value ) return $value;
+        if ( __( 'checked', 'ninja-forms' ) == $value ||
+             __( 'unchecked', 'ninja-forms' ) == $value ) return $value;
         if ( $value ) {
             return __( 'checked', 'ninja-forms' );
         } else {


### PR DESCRIPTION
Resolved a conflict with MailChimp, where checkboxes in Submissions were trying to render multiple times, causing them to always evaluate as checked.