### PR TITLE
Only scroll to success message if it isn't already fully visible #2626

### DIFF
--- a/assets/js/front-end/controllers/actionSuccess.js
+++ b/assets/js/front-end/controllers/actionSuccess.js
@@ -12,18 +12,20 @@ define([], function() {
 					
 					success_message.html( response.data.actions.success_message ).show();
 					
-					//Let's check if the success message is already visible in the viewport without scrolling
+					//Let's check if the success message is already fully visible in the viewport without scrolling
 					var top_of_success_message = success_message.offset().top;
-				    	var bottom_of_success_message = success_message.offset().top + success_message.outerHeight();
-				    	var bottom_of_screen = jQuery(window).scrollTop() + jQuery(window).height();
+			    	var bottom_of_success_message = success_message.offset().top + success_message.outerHeight();
+			    	var bottom_of_screen = jQuery(window).scrollTop() + jQuery(window).height();
+			    	var top_of_screen = jQuery(window).scrollTop();
 
-				    	if(!((bottom_of_screen > top_of_success_message) && (bottom_of_screen < bottom_of_success_message))){
-						//The element isn't visible, so let's scroll to the success message as in the previous release
+			    	var the_element_is_visible = ((bottom_of_screen > bottom_of_success_message) && (top_of_screen < top_of_success_message));
+
+			    	if(!the_element_is_visible){
+						//The element isn't visible, so let's scroll to the success message as in the previous release, but with a short animation
 						jQuery('html, body').animate({
 							scrollTop: ( success_message.offset().top - 50 )
-						}, 0 );
+						}, 300 );
 				   	}	
-				
 				}
 			}
 		}

--- a/assets/js/front-end/controllers/actionSuccess.js
+++ b/assets/js/front-end/controllers/actionSuccess.js
@@ -8,11 +8,22 @@ define([], function() {
 			if ( _.size( response.errors ) == 0 && 'undefined' != typeof response.data.actions ) {
 				if ( 'undefined' != typeof response.data.actions.success_message && '' != response.data.actions.success_message ) {
 					var form_id = response.data.form_id;
-					jQuery( '#nf-form-' + form_id + '-cont .nf-response-msg' ).html( response.data.actions.success_message ).show();
+					var success_message = jQuery( '#nf-form-' + form_id + '-cont .nf-response-msg' );
+					
+					success_message.html( response.data.actions.success_message ).show();
+					
+					//Let's check if the success message is already visible in the viewport without scrolling
+					var top_of_success_message = success_message.offset().top;
+				    	var bottom_of_success_message = success_message.offset().top + success_message.outerHeight();
+				    	var bottom_of_screen = jQuery(window).scrollTop() + jQuery(window).height();
 
-					jQuery('html, body').animate({
-						scrollTop: ( jQuery( '#nf-form-' + form_id + '-cont .nf-response-msg' ).offset().top - 50 )
-					}, 0 );
+				    	if(!((bottom_of_screen > top_of_success_message) && (bottom_of_screen < bottom_of_success_message))){
+						//The element isn't visible, so let's scroll to the success message as in the previous release
+						jQuery('html, body').animate({
+							scrollTop: ( success_message.offset().top - 50 )
+						}, 0 );
+				   	}	
+				
 				}
 			}
 		}

--- a/assets/js/front-end/controllers/actionSuccess.js
+++ b/assets/js/front-end/controllers/actionSuccess.js
@@ -14,18 +14,18 @@ define([], function() {
 					
 					//Let's check if the success message is already fully visible in the viewport without scrolling
 					var top_of_success_message = success_message.offset().top;
-			    	var bottom_of_success_message = success_message.offset().top + success_message.outerHeight();
-			    	var bottom_of_screen = jQuery(window).scrollTop() + jQuery(window).height();
-			    	var top_of_screen = jQuery(window).scrollTop();
+					var bottom_of_success_message = success_message.offset().top + success_message.outerHeight();
+					var bottom_of_screen = jQuery(window).scrollTop() + jQuery(window).height();
+					var top_of_screen = jQuery(window).scrollTop();
 
-			    	var the_element_is_visible = ((bottom_of_screen > bottom_of_success_message) && (top_of_screen < top_of_success_message));
+					var the_element_is_visible = ((bottom_of_screen > bottom_of_success_message) && (top_of_screen < top_of_success_message));
 
-			    	if(!the_element_is_visible){
+					if(!the_element_is_visible){
 						//The element isn't visible, so let's scroll to the success message as in the previous release, but with a short animation
 						jQuery('html, body').animate({
 							scrollTop: ( success_message.offset().top - 50 )
 						}, 300 );
-				   	}	
+					}	
 				}
 			}
 		}


### PR DESCRIPTION
Currently, if a form is fully visible when you hit submit, the window will jump so the success message is close to the top. This is disorienting for the user, so I adjusted the code to check if the success message is fully visible, and if so, to not scroll. If it isn't fully visible and it does need to scroll, I adjusted the animation time argument from 0 to 300 so it's less jarring. This resolves issue #2626 