### PR TITLE
Updating to remove php short tag.

### DIFF
--- a/includes/Templates/admin-menu-new-form.html.php
+++ b/includes/Templates/admin-menu-new-form.html.php
@@ -385,7 +385,7 @@
 
 <script id="tmpl-nf-staged-fields-drag" type="text/template">
     <div class="nf-staged-fields-drag">
-        <div id="drag-item-1" class="nf-staged-fields-drag-wrap">{{{ data.num }}}<? _e( ' Fields', 'ninja-forms' ); ?></div>
+        <div id="drag-item-1" class="nf-staged-fields-drag-wrap">{{{ data.num }}}<?php _e( ' Fields', 'ninja-forms' ); ?></div>
         <div id="drag-item-2" class="nf-staged-fields-drag-wrap">&nbsp;</div>
         <div id="drag-item-3" class="nf-staged-fields-drag-wrap">&nbsp;</div>
     </div>


### PR DESCRIPTION
Noticed this while debugging a Wordpress site running on a server with php short tags disabled. 

Short tags should be avoided, since using them requires a specific PHP configuration to work. See http://php.net/manual/en/language.basic-syntax.phptags.php.