### PR TITLE
Add sortable icons to sortable table headers [Dashboard - Widgets - Forms]

### DIFF
--- a/assets/scss/dashboard/widgets/forms.scss
+++ b/assets/scss/dashboard/widgets/forms.scss
@@ -6,6 +6,23 @@ th {
   .sortable {
     cursor: pointer;
     font-weight: bold;
+    margin-left: -5px;
+    &:hover {
+      &:after {
+        content: '\f0dc';
+      }
+    }
+    &:after {
+      font-family: 'FontAwesome';
+      margin-left: 5px;
+      position: absolute;
+    }
+    &.sorted-asc:after {
+      content: "\f0de";
+    }
+    &.sorted-desc:after {
+      content: "\f0dd";
+    }
   }
   header {
     display: flex;

--- a/client/dashboard/views/widgets/forms/formsTable.js
+++ b/client/dashboard/views/widgets/forms/formsTable.js
@@ -56,8 +56,18 @@ define( [
         },
 
         sortFormsTable: function( event ){
+            this.getUI( 'sortable' ).removeClass( 'sorted-asc' );
+            this.getUI( 'sortable' ).removeClass( 'sorted-desc' );
             var sortBy = jQuery( event.target ).data( 'sort' );
             var reverse = jQuery( event.target ).data( 'reverse' ) || 0;
+            if( reverse ){
+                jQuery( event.target ).addClass( 'sorted-desc' );
+                jQuery( event.target ).removeClass( 'sorted-asc' );
+            } else {
+                jQuery( event.target ).addClass( 'sorted-asc' );
+                jQuery( event.target ).removeClass( 'sorted-desc' );
+            }
+
             var collection = this.getChildView( 'body' ).collection;
 
             collection.comparator = function( a, b ) {


### PR DESCRIPTION
- Adds a [sort](http://fontawesome.io/icon/sort/) icon on hover, when un-sorted.
- Toggles a [sort-asc](http://fontawesome.io/icon/sort-asc/) or [sort-desc](http://fontawesome.io/icon/sort-desc/) icon, when sorted.

![image](https://cloud.githubusercontent.com/assets/10858303/26374584/c8cc0c44-3fd3-11e7-99ab-64eb73e8fb16.png)
