### PR TITLE
Correct the created_at and updated_at dates for mysql (issue #2061)

### DIFF
--- a/includes/Abstracts/Model.php
+++ b/includes/Abstracts/Model.php
@@ -473,10 +473,12 @@ class NF_Abstracts_Model
      */
     public function save()
     {
+        $data = array ( 'updated_at' => current_time( 'mysql' ));
+
         // If the ID is not set, assign an ID
         if( ! $this->_id ){
 
-            $data = array( 'created_at' => current_time('mysql') );
+            $data[  'created_at' ] = current_time( 'mysql' ) ;
 
             if( $this->_parent_id ){
                 $data['parent_id'] = $this->_parent_id;
@@ -509,7 +511,7 @@ class NF_Abstracts_Model
 
     public function _insert_row( $data = array() )
     {
-        $data[ 'created_at' ] = current_time('mysql');
+        $data[ 'created_at' ] = current_time( 'mysql' );
 
         if( $this->_parent_id ){
             $data['parent_id'] = $this->_parent_id;

--- a/includes/Abstracts/Model.php
+++ b/includes/Abstracts/Model.php
@@ -476,7 +476,7 @@ class NF_Abstracts_Model
         // If the ID is not set, assign an ID
         if( ! $this->_id ){
 
-            $data = array( 'created_at' => time() );
+            $data = array( 'created_at' => current_time('mysql') );
 
             if( $this->_parent_id ){
                 $data['parent_id'] = $this->_parent_id;
@@ -509,7 +509,7 @@ class NF_Abstracts_Model
 
     public function _insert_row( $data = array() )
     {
-        $data[ 'created_at' ] = time();
+        $data[ 'created_at' ] = current_time('mysql');
 
         if( $this->_parent_id ){
             $data['parent_id'] = $this->_parent_id;


### PR DESCRIPTION
This solves #2061 

Currently the code sets `created_at` to a timestamp when MySQL expects a MySQL DATETIME string.

Also, currently `updated_at` is never set at all. Since the MySQL schema does not set the `updated_at` to change on update, we'll set it here.