### PR TITLE
Minified javascript

### DIFF
--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -322,22 +322,7 @@ final class NF_Display_Render
 
         ?>
         <!-- TODO: Move to Template File. -->
-        <script>
-            var formDisplay = 1;
-
-            /* Maybe initialize nfForms object */
-            var nfForms = nfForms || [];
-
-            /* Build Form Data */
-            var form = [];
-            form.id = '<?php echo $form_id; ?>';
-            form.settings = <?php echo wp_json_encode( $form->get_settings() ); ?>;
-            form.fields = <?php echo wp_json_encode( $fields ); ?>;
-
-            /* Add Form Data to nfForms object */
-            nfForms.push( form );
-        </script>
-
+	<script>var formDisplay=1;var nfForms=nfForms||[];var form=[];form.id='<?php echo $form_id; ?>';form.settings=<?php echo wp_json_encode( $form->get_settings() ); ?>;form.fields=<?php echo wp_json_encode( $fields ); ?>;nfForms.push(form);</script>
         <?php
         self::enqueue_scripts( $form_id );
     }


### PR DESCRIPTION
I minified the javascript to prevent autop from adding extra <p></p> lines inside the script and resulting in errors and plugin broken when used in many templates and plugins filtering the_content.

Consider moving it to template file ASAP