### PR TITLE
Replace Tokenizer backticks in email_subject

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -364,7 +364,8 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
         }
 
         if( 'email' == $action[ 'type' ] ){
-            $action[ 'to' ] = str_replace( '`', ',', $action[ 'to' ] );
+            $action[ 'to' ]            = str_replace( '`', ',', $action[ 'to' ] );
+            $action[ 'email_subject' ] = str_replace( '`', ',', $action[ 'email_subject' ] );
         }
 
         // Convert `name` to `label`


### PR DESCRIPTION
Closes #2293.

The Tokenizer backticks were removed from the `$action['to']` setting, but not the `$action['email_subject']`.