### PR TITLE
Init NF_Session as needed

### DIFF
--- a/includes/Session.php
+++ b/includes/Session.php
@@ -57,7 +57,8 @@ class NF_Session {
         add_filter( 'wp_session_expiration_variant', array( $this, 'set_expiration_variant_time' ), 99999 );
         add_filter( 'wp_session_expiration', array( $this, 'set_expiration_time' ), 99999 );
 
-        add_action( 'plugins_loaded', array( $this, 'init' ), -1 );
+        // Since we only loading this as needed, we will need to call init() manually.
+        // add_action( 'plugins_loaded', array( $this, 'init' ), -1 );
 
     }
     /**

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -291,8 +291,6 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
                  */
                 self::$instance->_eos[ 'parser' ] = require_once 'includes/Libraries/EOS/Parser.php';
 
-                self::$instance->session = new NF_Session();
-
                 /*
                  * Plugin Settings
                  */
@@ -484,6 +482,10 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
 
         public function session()
         {
+            if( ! $this->session ){
+                $this->session = new NF_Session();
+                $this->session->init();
+            }
             return $this->session;
         }
 


### PR DESCRIPTION
Closes #2579.

`NF_Session` is only used by the `resume` feature of form submission.

Instead of initializing `NF_Session` on `plugins_loaded`, initialize as needed.