### PR TITLE
Whitelist post-new.php for the AddFormModal

### DIFF
--- a/includes/Admin/AddFormModal.php
+++ b/includes/Admin/AddFormModal.php
@@ -22,7 +22,7 @@ class NF_Admin_AddFormModal {
     public function insert_form_tinymce_buttons( $context ) {
         global $pagenow;
 
-        if ( 'post.php' != $pagenow ) {
+        if( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ) ) ){
             return $context;
         }
         $html = '<style>


### PR DESCRIPTION
Closes #1481.

The check for `post.php` was overly specific and did not allow for new posts/pages, `post-new.php`.