### PR TITLE
Use reset to get the first array item in WP_Helper::get_query_string

### DIFF
--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -198,7 +198,7 @@ final class WPN_Helper
 
         $value = self::htmlspecialchars( $_GET[ $key ] );
 
-        if( is_array( $value ) ) $value = $value[ 0 ];
+        if( is_array( $value ) ) $value = reset( $value );
 
         return $value;
     }


### PR DESCRIPTION
Closes #2418.

We were using `$value[0]` to get the first array item, but this assumes a numeric key structure.

Instead use PHP's `reset` to get the first item, regardless of the key stsructure.

> reset() rewinds array's internal pointer to the first element and returns the value of the first array element.
Source: http://php.net/manual/en/function.reset.php