### PR TITLE
Add missing key and admin_label settings to the StarRating field

### DIFF
--- a/includes/Fields/StarRating.php
+++ b/includes/Fields/StarRating.php
@@ -17,7 +17,7 @@ class NF_Fields_StarRating extends NF_Abstracts_Input
 
     protected $_templates = 'starrating';
 
-    protected $_settings_only = array( 'label', 'label_pos', 'default', 'required', 'classes' );
+    protected $_settings_only = array( 'label', 'label_pos', 'default', 'required', 'classes', 'key', 'admin_label' );
 
     public function __construct()
     {


### PR DESCRIPTION
Closes #2645.

When adding specific settings for the Star Rating field, the settings `key` and `admin_label` were missed.