### PR TITLE
Remove utf8 encoding from the form cache.

### DIFF
--- a/includes/Admin/Menus/Forms.php
+++ b/includes/Admin/Menus/Forms.php
@@ -251,11 +251,6 @@ final class NF_Admin_Menus_Forms extends NF_Abstracts_Menu
 
         $fields_settings = array();
 
-        // echo "<pre>";
-        // print_r( $fields );
-        // echo "</pre>";
-        // die();
-
         if( ! empty( $fields ) ) {
 
             // TODO: Replace unique field key checks with a refactored model/factory.

--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -121,7 +121,7 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             ));
         }
 
-        update_option( 'nf_form_' . $form_id, WPN_Helper::utf8_encode( $form_cache ) );
+        update_option( 'nf_form_' . $form_id, $form_cache );
 
         add_action( 'admin_notices', array( 'NF_Database_Models_Form', 'import_admin_notice' ) );
 


### PR DESCRIPTION
Closes #2401.

Reverts d005c8a. Not sure of the implications of reverting this change, but it does resolve the current encoding issues.