### PR TITLE
Resolve bug with missing merge fields if post meta field present

### DIFF
--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -71,7 +71,7 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
             $subject = str_replace( $search, $this->post_meta[ $meta_key ], $subject );
         }
 
-        return $subject;
+      return parent::replace( $subject );
     }
 
     protected function post_id()


### PR DESCRIPTION
When merging post meta data fields, other fields would not populate. Looks
to have been because the parent replace function was never called on the
subject.

Resolves #2799