### PR TITLE
Submit disabled on failed reCaptcha

### DIFF
--- a/includes/Fields/Recaptcha.php
+++ b/includes/Fields/Recaptcha.php
@@ -50,7 +50,7 @@ class NF_Fields_Recaptcha extends NF_Abstracts_Field
 
     public function validate( $field, $data ) {
         if ( empty( $field['value'] ) ) {
-            return array( __( 'Please complete the recaptcha', 'ninja-forms' ) );
+            return __( 'Please complete the recaptcha', 'ninja-forms' );
         }
 
         $secret_key = Ninja_Forms()->get_setting( 'recaptcha_secret_key' );


### PR DESCRIPTION
Modified error logic for reCaptcha so that it now properly handles a failed submission.