### PR TITLE
Locale-based language selection for reCAPTCHA

### DIFF
--- a/deprecated/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/deprecated/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -72,7 +72,7 @@ function ninja_forms_register_general_settings_metabox(){
                 'name'     => 'recaptcha_lang',
                 'type'     => 'text',
                 'label' => __( 'reCAPTCHA Language', 'ninja-forms' ),
-                'desc'     => 'e.g. en, da, locale - ' . sprintf( __( 'Language used by reCAPTCHA. Use "locale" to dynamically use the current language. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
+                'desc'     => 'e.g. en, da - ' . sprintf( __( 'Language used by reCAPTCHA. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
             ),
         ),
         'state' => 'closed',

--- a/deprecated/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
+++ b/deprecated/includes/admin/pages/ninja-forms-settings/tabs/general-settings/general-settings.php
@@ -72,7 +72,7 @@ function ninja_forms_register_general_settings_metabox(){
                 'name'     => 'recaptcha_lang',
                 'type'     => 'text',
                 'label' => __( 'reCAPTCHA Language', 'ninja-forms' ),
-                'desc'     => 'e.g. en, da - ' . sprintf( __( 'Language used by reCAPTCHA. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
+                'desc'     => 'e.g. en, da, locale - ' . sprintf( __( 'Language used by reCAPTCHA. Use "locale" to dynamically use the current language. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
             ),
         ),
         'state' => 'closed',

--- a/includes/Config/PluginSettingsReCaptcha.php
+++ b/includes/Config/PluginSettingsReCaptcha.php
@@ -38,7 +38,7 @@ return apply_filters( 'ninja_forms_plugin_settings_recaptcha', array(
         'id'    => 'recaptcha_lang',
         'type'  => 'textbox',
         'label' => __( 'reCAPTCHA Language', 'ninja-forms' ),
-        'desc'  => 'e.g. en, da - ' . sprintf( __( 'Language used by reCAPTCHA. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
+        'desc'  => 'e.g. en, da, locale - ' . sprintf( __( 'Language used by reCAPTCHA. Use "locale" to dynamically use the current language. To get the code for your language click %shere%s', 'ninja-forms' ), '<a href="https://developers.google.com/recaptcha/docs/language" target="_blank">', '</a>' )
     ),
 
     /*

--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -512,6 +512,10 @@ final class NF_Display_Render
 
         if( $is_preview || in_array( $form_id, self::$form_uses_recaptcha ) ) {
             $recaptcha_lang = Ninja_Forms()->get_setting('recaptcha_lang');
+			## if set to 'locale', use current locale, else use given language
+			if( $recaptcha_lang == 'locale' ) {
+				$recaptcha_lang = split('_',  get_locale())[0];
+			}
             wp_enqueue_script('nf-google-recaptcha', 'https://www.google.com/recaptcha/api.js?hl=' . $recaptcha_lang . '&onload=nfRenderRecaptcha&render=explicit', array( 'jquery', 'nf-front-end-deps' ), $ver, TRUE );
         }
 


### PR DESCRIPTION
We use ninja-forms in our multi-lang website and needed a way for the reCAPTCHA to use the language defined in the locale, as set by the current anonymous user.
So we use the keyword "locale" in the reCAPTCHA settings and, if defined, set the language accordingly when rendering.  