### PR TITLE
Add missing return statement for Migration charset_collate() method.

### DIFF
--- a/includes/Abstracts/Migration.php
+++ b/includes/Abstracts/Migration.php
@@ -24,7 +24,7 @@ abstract class NF_Abstracts_Migration
     public function charset_collate()
     {
         global $wpdb;
-        $wpdb->get_charset_collate();
+        return $wpdb->get_charset_collate();
     }
 
     public function _run()


### PR DESCRIPTION
 Closes #2988.

... and this is why we have code reviews.