### PR TITLE
Update checkbox merge tag value filtering.

### DIFF
--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -58,23 +58,8 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
 
     public function filter_merge_tag_value( $value, $field )
     {
-        if( $value ){
-            if( isset( $field[ 'checked_calc_value' ] ) && '' != $field[ 'checked_calc_value' ] ) {
-                return $field['checked_calc_value'];
-            } else {
-                return __( 'checked', 'ninja-forms' );
-            }
-        }
-
-        if( ! $value ){
-            if( isset( $field[ 'unchecked_calc_value' ] ) && '' != $field[ 'unchecked_calc_value' ] ) {
-                return $field['unchecked_calc_value'];
-            } else {
-                return __( 'unchecked', 'ninja-forms' );
-            }
-        }
-
-        return $value;
+        if( $value ) return __( 'checked', 'ninja-forms' );
+        return __( 'unchecked', 'ninja-forms' );
     }
 
     public function filter_merge_tag_value_calc( $value, $field )


### PR DESCRIPTION
Checkbox merge tag value were being overridden by the calc value settings.
Since calculation context was added this setting no longer needs to override the value by default.

This also fixes an issue with conversion, in which the calc value settings had a default value of `0` - causing the issue in the THREE codebase.

Closes #2993 .
Closes #2468 .