### PR TITLE
Only populate WP merge tags on ninja-forms pages.

### DIFF
--- a/includes/MergeTags/Deprecated.php
+++ b/includes/MergeTags/Deprecated.php
@@ -29,6 +29,9 @@ final class NF_MergeTags_Deprecated extends NF_Abstracts_MergeTags
     {
         global $post;
 
+        // If in the admin, only run on Ninja Forms pages.
+        if( is_admin() && ( ! isset( $_GET[ 'page' ] ) || 'ninja-forms' !== $_GET[ 'page' ] ) ) return;
+
         $this->setup_post_meta( $this->post_id() );
     }
 

--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -30,6 +30,9 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
     {
         global $post;
 
+        // If in the admin, only run on Ninja Forms pages.
+        if( is_admin() && ( ! isset( $_GET[ 'page' ] ) || 'ninja-forms' !== $_GET[ 'page' ] ) ) return;
+
         $this->setup_post_meta( $this->post_id() );
     }
 


### PR DESCRIPTION
The WP - and Deprecated - merge tag classes were running queries to populate merge tag value on non `ninja-forms` admin pages.

Closes #2970.