### PR TITLE
License Activation Error Notice

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -60,11 +60,17 @@ class NF_Admin_Notices
         }
 
         foreach ( $admin_notices as $slug => $admin_notice ) {
-            // Call for spam protection
-            if ( $this->anti_notice_spam() ) {
-                return false;
+
+            if ( isset ( $admin_notice[ 'ignore_spam' ] ) && true == $admin_notice[ 'ignore_spam' ] ) {
+                $ignore_spam = true;
+            } else {
+                $ignore_spam = false;
             }
 
+            // Call for spam protection
+            if ( ! $ignore_spam && $this->anti_notice_spam() ) {
+                continue;
+            }
 
             // Check for proper page to display on
             if ( isset( $admin_notices[ $slug ][ 'pages' ] ) && is_array( $admin_notices[ $slug ][ 'pages' ] )
@@ -74,9 +80,11 @@ class NF_Admin_Notices
                 if( ( isset( $admin_notices[ $slug ][ 'blacklist' ] ) && $this->admin_notice_pages_blacklist( $admin_notices[ $slug ][ 'blacklist' ] ) )
                     || ( isset( $admin_notices[ $slug ][ 'pages' ] ) && ! $this->admin_notice_pages( $admin_notices[ $slug ][ 'pages' ] ) )
                 ) {
-                    return false;
+                    continue;
                 }
             }
+
+            
 
             // Check for required fields
             if ( ! $this->required_fields( $admin_notices[ $slug ] ) ) {
@@ -138,6 +146,8 @@ class NF_Admin_Notices
                 }
             }
         }
+
+        // die( 'done looping' );
     }
 
     // Spam protection check

--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -84,8 +84,6 @@ class NF_Admin_Notices
                 }
             }
 
-            
-
             // Check for required fields
             if ( ! $this->required_fields( $admin_notices[ $slug ] ) ) {
 
@@ -146,8 +144,6 @@ class NF_Admin_Notices
                 }
             }
         }
-
-        // die( 'done looping' );
     }
 
     // Spam protection check

--- a/includes/Integrations/EDD/class-extension-updater.php
+++ b/includes/Integrations/EDD/class-extension-updater.php
@@ -94,8 +94,6 @@ class NF_Extension_Updater
                 add_filter( 'nf_admin_notices', array( $this, 'show_license_error_notice' ) );
                 $this->_last_error = var_export( $license_data, true );
             }
-        }
-
         } else {
             $error = '';
         }

--- a/includes/Integrations/EDD/class-extension-updater.php
+++ b/includes/Integrations/EDD/class-extension-updater.php
@@ -17,6 +17,7 @@ class NF_Extension_Updater
     public $file = '';
     public $author = '';
     public $error = '';
+    private $_last_error;
 
     /**
      * Constructor function
@@ -87,6 +88,14 @@ class NF_Extension_Updater
 
         if ( 'invalid' == $license_data->license ) {
             $error = '<span style="color: red;">' . __( 'Could not activate license. Please verify your license key', 'ninja-forms' ) . '</span>';
+            
+            if ( isset ( $_REQUEST[ 'nf_debug' ] ) && 1 == absint( $_REQUEST[ 'nf_debug' ] ) ) {
+                // Add an error to our admin notice if nf_debug is turned on.
+                add_filter( 'nf_admin_notices', array( $this, 'show_license_error_notice' ) );
+                $this->_last_error = var_export( $license_data, true );
+            }
+        }
+
         } else {
             $error = '';
         }
@@ -94,6 +103,17 @@ class NF_Extension_Updater
         Ninja_Forms()->update_setting( $this->product_name . '_license', $license_key );
         Ninja_Forms()->update_setting( $this->product_name . '_license_error', $error );
         Ninja_Forms()->update_setting( $this->product_name . '_license_status', $license_data->license );
+    }
+
+    public function show_license_error_notice( $notices ) {
+        $notices[ 'license_error' ] = array(
+            'title' => __( 'License Activation Error', 'ninja-forms' ),
+            'msg' => '<pre>' . $this->_last_error . '</pre>',
+            'int' => 0,
+            'ignore_spam' => true,
+        );
+
+        return $notices;
     }
 
     /*


### PR DESCRIPTION
Adding a notice to the settings screen when a license activation error occurs and the nf_debug querystring is set to 1. Closes #3042.

I had to update the Notices.php file because it was returning early when there was an issue while looping over admin notices instead of continuing. This made it impossible to fire later notices when an early one should have been skipped.

I also added a flag for admin notices called "ignore_spam" which tells the admin notice class you want the notice to display, regardless of how many Ninja Forms notices there are on the screen.