### PR TITLE
Fixed a bug with blacklisting blocking future notices.

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -74,7 +74,7 @@ class NF_Admin_Notices
                 if( ( isset( $admin_notices[ $slug ][ 'blacklist' ] ) && $this->admin_notice_pages_blacklist( $admin_notices[ $slug ][ 'blacklist' ] ) )
                     || ( isset( $admin_notices[ $slug ][ 'pages' ] ) && ! $this->admin_notice_pages( $admin_notices[ $slug ][ 'pages' ] ) )
                 ) {
-                    return false;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
The opt-in notice was not being shown because the blacklist check of a previous notice was early returning, instead of continuing the loop.

Closes #3057 .