### PR TITLE
Added filter to hide marketing tools for developers/agencies.

### DIFF
--- a/includes/Admin/Menus/Addons.php
+++ b/includes/Admin/Menus/Addons.php
@@ -10,7 +10,10 @@ final class NF_Admin_Menus_Addons extends NF_Abstracts_Submenu
 
     public function __construct()
     {
-        parent::__construct();
+        $disable_marketing = false;
+        if ( ! apply_filters( 'ninja_forms_disable_marketing', $disable_marketing ) ) {
+            parent::__construct();
+        }
     }
 
     public function get_page_title()

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -373,16 +373,19 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
                 Ninja_Forms()->dispatcher()->send( 'upgrade' );
             }
 
-            add_filter( 'ninja_forms_dashboard_menu_items', function ( $items ) {
-                $disable_marketing = false;
-                if ( apply_filters( 'ninja_forms_disable_marketing', $disable_marketing ) ) {
-                    unset(
-                        $items[ 'apps' ],
-                        $items[ 'memberships' ]
-                    );
-                }
-                return $items;
-            } );
+            add_filter( 'ninja_forms_dashboard_menu_items', array( $this, 'maybe_hide_dashboard_items' ) );
+        }
+        
+        public function maybe_hide_dashboard_items( $items )
+        {
+            $disable_marketing = false;
+            if ( apply_filters( 'ninja_forms_disable_marketing', $disable_marketing ) ) {
+                unset(
+                    $items[ 'apps' ],
+                    $items[ 'memberships' ]
+                );
+            }
+            return $items;
         }
 
         public function scrub_available_actions( $actions )

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -372,6 +372,17 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
             if ( isset ( $_GET[ 'nf-upgrade' ] ) && 'complete' == $_GET[ 'nf-upgrade' ] ) {
                 Ninja_Forms()->dispatcher()->send( 'upgrade' );
             }
+
+            add_filter( 'ninja_forms_dashboard_menu_items', function ( $items ) {
+                $disable_marketing = false;
+                if ( apply_filters( 'ninja_forms_disable_marketing', $disable_marketing ) ) {
+                    unset(
+                        $items[ 'apps' ],
+                        $items[ 'memberships' ]
+                    );
+                }
+                return $items;
+            } );
         }
 
         public function scrub_available_actions( $actions )


### PR DESCRIPTION
Fixes https://github.com/wpninjas/ninja-forms/issues/2879

To test, paste the following into your `functions.php` file, or a custom plugin:

```php
add_filter( 'ninja_forms_disable_marketing', '__return_true' );
```

