### PR TITLE
Remove extra commas from email address settings.

### DIFF
--- a/includes/Actions/Email.php
+++ b/includes/Actions/Email.php
@@ -47,6 +47,8 @@ final class NF_Actions_Email extends NF_Abstracts_Action
 
     public function process( $action_settings, $form_id, $data )
     {
+        $action_settings = $this->sanitize_address_fields( $action_settings );
+
         $errors = $this->check_for_errors( $action_settings );
 
         $headers = $this->_get_headers( $action_settings );
@@ -83,6 +85,7 @@ final class NF_Actions_Email extends NF_Abstracts_Action
             $errors[ 'email_not_sent' ] = $e->getMessage();
         }
 
+
         if( is_user_logged_in() && current_user_can( 'manage_options' ) ) {
             $data[ 'actions' ][ 'email' ][ 'to' ] = $action_settings[ 'to' ];
             $data[ 'actions' ][ 'email' ][ 'headers' ] = $headers;
@@ -103,6 +106,53 @@ final class NF_Actions_Email extends NF_Abstracts_Action
         return $data;
     }
 
+    /**
+     * Sanitizes email address settings
+     * @since 3.2.2
+     *
+     * @param  array $action_settings
+     * @return array
+     */
+    protected function sanitize_address_fields( $action_settings )
+    {
+        // Build a look array to compare our email address settings to.
+        $email_address_settings = array( 'to', 'from_address', 'reply_to', 'cc', 'bcc' );
+
+        // Loop over the look up values.
+        foreach( $email_address_settings as $setting ) {
+            // If the loop up values are not set in the action settings continue.
+            if ( ! isset( $action_settings[ $setting ] ) ) continue;
+
+            // If action settings do not match the look up values continue.
+            if ( ! $action_settings[ $setting ] ) continue;
+
+            // This is the array that will contain the sanitized email address values.
+            $sanitized_array = array();
+
+            /*
+             * Checks to see action settings is array,
+             * if not explodes to comma delimited array.
+             */
+            if( is_array( $action_settings[ $setting ] ) ) {
+                $email_addresses = $action_settings[ $setting ];
+            } else {
+                $email_addresses = explode( ',', $action_settings[ $setting ] );
+            }
+
+            // Loop over our email addresses.
+            foreach( $email_addresses as $email ) {
+                // Removes empty values that are passed in.
+                if( empty( $email ) ) continue;
+
+                // Build our array of the email addresses.
+                $sanitized_array[] = $email;
+            }
+            // Sanitized our array of settings.
+            $action_settings[ $setting ] = implode( ',' ,$sanitized_array );
+        }
+        return $action_settings;
+    }
+
     protected function check_for_errors( $action_settings )
     {
         $errors = array();
@@ -115,6 +165,7 @@ final class NF_Actions_Email extends NF_Abstracts_Action
 
 
             $email_addresses = is_array( $action_settings[ $setting ] ) ? $action_settings[ $setting ] : explode( ',', $action_settings[ $setting ] );
+
             foreach( (array) $email_addresses as $email ){
                 $email = trim( $email );
                 if ( false !== strpos( $email, '<' ) && false !== strpos( $email, '>' ) ) {

--- a/includes/Actions/Email.php
+++ b/includes/Actions/Email.php
@@ -142,7 +142,7 @@ final class NF_Actions_Email extends NF_Abstracts_Action
             // Loop over our email addresses.
             foreach( $email_addresses as $email ) {
 
-				// Updated to trim values in case there is a value with spaces/tabs/etc to remove whitespace
+		// Updated to trim values in case there is a value with spaces/tabs/etc to remove whitespace
                 if( empty( trim( $email ) ) ) continue;
 
                 // Build our array of the email addresses.

--- a/includes/Actions/Email.php
+++ b/includes/Actions/Email.php
@@ -141,8 +141,9 @@ final class NF_Actions_Email extends NF_Abstracts_Action
 
             // Loop over our email addresses.
             foreach( $email_addresses as $email ) {
-                // Removes empty values that are passed in.
-                if( empty( $email ) ) continue;
+
+				// Updated to trim values in case there is a value with spaces/tabs/etc to remove whitespace
+                if( empty( trim( $email ) ) ) continue;
 
                 // Build our array of the email addresses.
                 $sanitized_array[] = $email;

--- a/includes/Actions/Email.php
+++ b/includes/Actions/Email.php
@@ -85,7 +85,6 @@ final class NF_Actions_Email extends NF_Abstracts_Action
             $errors[ 'email_not_sent' ] = $e->getMessage();
         }
 
-
         if( is_user_logged_in() && current_user_can( 'manage_options' ) ) {
             $data[ 'actions' ][ 'email' ][ 'to' ] = $action_settings[ 'to' ];
             $data[ 'actions' ][ 'email' ][ 'headers' ] = $headers;


### PR DESCRIPTION
Fixes # 2974

Changes proposed in this pull request:
- Created a helper method in the email action that removes extra comma separators from email settings(ie To, BCC, CC, reply-to, and from address'). 

Testing Steps:
1. Create a form with multiple email address fields. 
2. Set the email address fields as settings in the TO, BCC, CC, reply-to, or from address as comma 
separated merge tags. 
3. Submit the form and see if the email goes through. 

@wpninjas/developers 
