### PR TITLE
Include submission on the end_date.

### DIFF
--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -418,6 +418,9 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         $begin_date = $_GET[ 'begin_date' ];
         $end_date = $_GET[ 'end_date' ];
 
+        // Include submissions on the end_date.
+        $end_date = date( 'm/d/Y', strtotime( '+1 day', strtotime( $end_date ) ) );
+
         if( $begin_date > $end_date ){
             $temp_date = $begin_date;
             $begin_date = $end_date;


### PR DESCRIPTION
This Pull Request includes submissions that fall on the `end_date` in the search by extending the `after` parameter by `+1 day`.

Closes #2749.
