### PR TITLE
Add check before accessing the 'tag' array index

### DIFF
--- a/includes/Abstracts/MergeTags.php
+++ b/includes/Abstracts/MergeTags.php
@@ -42,7 +42,7 @@ abstract class NF_Abstracts_MergeTags
         if( empty( $matches[0] ) ) return $subject;
 
         foreach( $this->merge_tags as $merge_tag ){
-            if( ! in_array( $merge_tag[ 'tag' ], $matches[0] ) ) continue;
+            if( ! isset( $merge_tag[ 'tag' ] ) || ! in_array( $merge_tag[ 'tag' ], $matches[0] ) ) continue;
 
             if( ! isset($merge_tag[ 'callback' ])) continue;
 


### PR DESCRIPTION
Add check to make sure array index tag is set before attempting to access it.

Fixes #2827 

Changes proposed in this pull request:

- Check to make sure the 'tag' index of $merge_tag exists before running the in_array() check

@wpninjas/developers 
