### PR TITLE
Check if setting value is empty, not just ! isset, and return default

### DIFF
--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -550,7 +550,7 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
 	     */
         public function get_setting( $key = '', $default = false )
         {
-            if( empty( $key ) || ! isset( $this->settings[ $key ] ) ) return $default;
+            if( empty( $key ) || ! isset( $this->settings[ $key ] ) || empty( $this->settings[ $key ] ) ) return $default;
 
             return $this->settings[ $key ];
         }


### PR DESCRIPTION
Before
```php
$value = Ninja_Forms()->get_setting( 'foo', /* $default */'bar' ); // $value: 'bar'

Ninja_Forms()->update_setting( 'foo', '' );

$value = Ninja_Forms()->get_setting( 'foo', /* $default */'bar' ); // $value: ''
```

After
```php
$value = Ninja_Forms()->get_setting( 'foo', /* $default */'bar' ); // $value: 'bar'

Ninja_Forms()->update_setting( 'foo', '' );

$value = Ninja_Forms()->get_setting( 'foo', /* $default */'bar' ); // $value: 'bar'
```

This creates an issue in Recurly, where the button labels are blank after the setting is "cleared".

Closes #3094
Closes wpninjas/ninja-forms-recurly#14
