### PR TITLE
Resolve add new template syntax error

### DIFF
--- a/includes/Abstracts/ModelFactory.php
+++ b/includes/Abstracts/ModelFactory.php
@@ -128,14 +128,14 @@ class NF_Abstracts_ModelFactory
     public function import_form( $import, $id = FALSE, $is_conversion = FALSE )
     {
         
-        /*
-         * Remove any unwated (corrupted?) characters from either side of our object.
-         */
-        $l_trim = strpos( $import, '{' );
-        $r_trim = strrpos( $import, '}' ) - $l_trim + 1;
-        $import = substr( $import, $l_trim, $r_trim );
-        
         if( ! is_array( $import ) ){
+
+            /*
+             * Remove any unwated (corrupted?) characters from either side of our object.
+             */
+            $l_trim = strpos( $import, '{' );
+            $r_trim = strrpos( $import, '}' ) - $l_trim + 1;
+            $import = substr( $import, $l_trim, $r_trim );
 
             $data = WPN_Helper::utf8_decode( json_decode( html_entity_decode( $import ), true ) );
 

--- a/includes/Config/i18nFrontEnd.php
+++ b/includes/Config/i18nFrontEnd.php
@@ -25,5 +25,6 @@ return apply_filters( 'ninja_forms_i18n_front_end', array(
     'thousands_sep'                         => $wp_locale->number_format[ 'thousands_sep' ],
     'decimal_point'                         => $wp_locale->number_format[ 'decimal_point' ],
     'dateFormat'                            => $date_format,
-    'startOfWeek'                           => get_option( 'start_of_week' )
+    'startOfWeek'                           => get_option( 'start_of_week' ),
+    'of'                                    => __( 'of', 'ninja-forms' )
 ));

--- a/includes/Templates/field-input-limit.html
+++ b/includes/Templates/field-input-limit.html
@@ -1,3 +1,3 @@
 <script id="tmpl-nf-field-input-limit" type="text/template">
-    {{{ data.currentCount() }}} of {{{ data.input_limit }}} {{{ data.input_limit_msg }}}
+    {{{ data.currentCount() }}} {{{ nfi18n.of }}} {{{ data.input_limit }}} {{{ data.input_limit_msg }}}
 </script>


### PR DESCRIPTION
- Moved trim of imports to inside of not is array check to ensure that we do not try to trim an array, breaking functionality.
- Added translatable text for the (of) in the input limit text.

@wpninjas/developers 
