### PR TITLE
Sorts options in ListCountry fields by name #3117

### DIFF
--- a/includes/Fields/ListCountry.php
+++ b/includes/Fields/ListCountry.php
@@ -60,7 +60,11 @@ class NF_Fields_ListCountry extends NF_Abstracts_List
             $options[ $key ][ 'selected' ] = 1;
         }
 
-        return $options;
+	    uasort( $options, function ( $a, $b ) {
+		    return strcasecmp( $a['label'], $b['label'] );
+	    } );
+
+	    return array_values( $options );
     }
 
     public function filter_options_preview( $field_settings )

--- a/includes/Fields/ListCountry.php
+++ b/includes/Fields/ListCountry.php
@@ -60,12 +60,15 @@ class NF_Fields_ListCountry extends NF_Abstracts_List
             $options[ $key ][ 'selected' ] = 1;
         }
 
-	    uasort( $options, function ( $a, $b ) {
-		    return strcasecmp( $a['label'], $b['label'] );
-	    } );
+		usort( $options, array($this,'sort_options_by_label') );
 
-	    return array_values( $options );
-    }
+		return $options;
+	}
+
+	private function sort_options_by_label( $option_a, $option_b )
+	{
+		return strcasecmp( $option_a['label'], $option_b['label'] );
+	}
 
     public function filter_options_preview( $field_settings )
     {


### PR DESCRIPTION
Fixes #3117

Changes proposed in this pull request:
- When adding a country field, the sort seems to be based on the value. This PR fixes that sorting ListCountry fields by country name.

@wpninjas/developers 
