### PR TITLE
Add ability to display the Form ID and Form Title on the Submissions …

### DIFF
--- a/includes/Admin/CPT/Submission.php
+++ b/includes/Admin/CPT/Submission.php
@@ -163,6 +163,10 @@ class NF_Admin_CPT_Submission
 
         $columns['sub_date'] = __( 'Date', 'ninja-forms' );
 
+        $columns['form_id'] = __( 'Form ID', 'ninja-forms' );
+
+        $columns['form_title'] = __( 'Form Title', 'ninja-forms' );
+
         return $columns;
     }
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -104,6 +104,10 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 
         $cols[ 'sub_date' ] = __( 'Date', 'ninja-forms' );
 
+        $cols [ 'form_id' ] = __( 'Form ID', 'ninja-foms' );
+
+        $cols [ 'form_title' ] = __( 'Form Title', 'ninja-foms' );
+
         return $cols;
     }
 
@@ -123,6 +127,12 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
                 break;
             case 'sub_date':
                 echo $this->custom_columns_sub_date( $sub );
+                break;
+            case 'form_id':
+                echo $this->custom_columns_form_id( $sub );
+                break;
+            case 'form_title':
+                echo $this->custom_columns_form_title( $sub );
                 break;
             default:
                 echo $this->custom_columns_field( $sub, $column );
@@ -372,12 +382,34 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
     /**
      * Custom Columns: Submission Date
      *
-     * @param $sub
-     * @return mixed
+     * @param NF_Database_Models_Submission $sub
+     * @return string
      */
     private function custom_columns_sub_date( $sub )
     {
         return $sub->get_sub_date( 'm/d/Y h:i A' );
+    }
+
+    /**
+     * Custom Columns: Form ID
+     *
+     * @param NF_Database_Models_Submission $sub
+     * @return int
+     */
+    private function custom_columns_form_id( $sub )
+    {
+        return $sub->get_form_id();
+    }
+
+    /**
+     * Custom Columns: Form Name
+     *
+     * @param NF_Database_Models_Submission $sub
+     * @return string
+     */
+    private function custom_columns_form_title( $sub )
+    {
+        return $sub->get_form_title();
     }
 
     /**


### PR DESCRIPTION
Add the ability to display the _Form ID_ and the _Form Title_ in the Submissions table.

*Note* I currently did not add this data to _Export_ and _Download All_ as the column filters does not currently change the output of this data. Adding the new data may cause issues with people who have templates set up for consuming this data.  This would need a larger conversation.

@wpninjas/developers 
