### PR TITLE
Fix entites when saved as value in a select box, not showing on submi…

### DIFF
--- a/includes/Abstracts/List.php
+++ b/includes/Abstracts/List.php
@@ -54,17 +54,20 @@ abstract class NF_Abstracts_List extends NF_Abstracts_Field
         return "<select class='widefat' name='fields[$id]' id=''>$options</select>";
     }
 
+    /*
+     * Appropriate output for a column cell in submissions list.
+     */
     public function custom_columns( $value, $field )
     {
         if( $this->_name != $field->get_setting( 'type' ) ) return $value;
-
-        if( ! is_array( $value ) ) $value = array( $value );
+        
+        //Consider &amp; to be the same as the & values in database in a selectbox saved value:
+        if( ! is_array( $value ) ) $value = array( htmlspecialchars_decode($value) );
 
         $output = '';
         $options = $field->get_setting( 'options' );
         if( ! empty( $options ) ) {
             foreach ($options as $option) {
-
                 if (!in_array($option['value'], $value)) continue;
 
                 $output .= $option['label'] . "<br />";


### PR DESCRIPTION
Fixes #3055

Changes proposed in this pull request:
- Match based on the value, not a html string. Alternately it could probably always output the select item when only one is chosen (like a selectbox!)

@wpninjas/developers 
