### PR TITLE
Added an escape to remove place holders from the where clause.

### DIFF
--- a/deprecated/classes/subs-cpt.php
+++ b/deprecated/classes/subs-cpt.php
@@ -598,13 +598,16 @@ class NF_Subs_CPT {
 
 			if (!empty($query)) {
 				// add to where clause
-				$pieces['where'] = str_replace("((({$wpdb->posts}.post_title LIKE '%", "( {$query} (({$wpdb->posts}.post_title LIKE '%", $pieces['where']);
+				// Escape place holders for the where clause.
+				$pieces[ 'where' ] = $wpdb->remove_placeholder_escape( $pieces[ 'where' ] );
 
-				$pieces['join'] = $pieces['join'] . " INNER JOIN {$wpdb->postmeta} AS mypm1 ON ({$wpdb->posts}.ID = mypm1.post_id)";
+				$pieces[ 'where' ] = str_replace("((({$wpdb->posts}.post_title LIKE '%", "({$query}(({$wpdb->posts}.post_title LIKE '%", $pieces[ 'where' ]);
+
+				$pieces[ 'join' ] = $pieces[ 'join' ] . " INNER JOIN {$wpdb->postmeta} AS mypm1 ON ({$wpdb->posts}.ID = mypm1.post_id)";
 
 			}
 		}
-		return ($pieces);
+		return ( $pieces );
 	}
 
 	/**

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -212,6 +212,7 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
             global $wpdb;
 
             $keywords = explode(' ', get_query_var('s'));
+
             $query = "";
 
             foreach ($keywords as $word) {
@@ -220,14 +221,17 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
             }
 
             if (!empty($query)) {
-                // add to where clause
-                $pieces['where'] = str_replace("((({$wpdb->posts}.post_title LIKE '%", "( {$query} (({$wpdb->posts}.post_title LIKE '%", $pieces['where']);
+                // Escape place holders for the where clause.
+                $pieces[ 'where' ] = $wpdb->remove_placeholder_escape( $pieces[ 'where' ] );
 
-                $pieces['join'] = $pieces['join'] . " INNER JOIN {$wpdb->postmeta} AS mypm1 ON ({$wpdb->posts}.ID = mypm1.post_id)";
+                // add to where clause
+                $pieces[ 'where' ] = str_replace("((({$wpdb->posts}.post_title LIKE '%", "({$query}(({$wpdb->posts}.post_title LIKE '%", $pieces[ 'where' ]);
+
+                $pieces[ 'join' ] = $pieces[ 'join' ] . " INNER JOIN {$wpdb->postmeta} AS mypm1 ON ({$wpdb->posts}.ID = mypm1.post_id)";
 
             }
         }
-        return ($pieces);
+        return ( $pieces );
     }
 
     public function remove_bulk_edit( $actions ) {


### PR DESCRIPTION
Fixes #3182 

Changes proposed in this pull request:
- Added an escape to remove place holders(%) from the "where" clause. I wanted another set of eyes on this to see if this fix makes sense. I'm not sure if this fix could break anything else or not. We will also need to fix this in the 2.9.x codebase if approved. 

@wpninjas/developers 
