### PR TITLE
Change output template file path

### DIFF
--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -617,7 +617,7 @@ final class NF_Display_Render
     {
         // Build File Path Hierarchy
         $file_paths = apply_filters( 'ninja_forms_field_template_file_paths', array(
-            get_template_directory() . '/ninja-forms/templates/',
+            get_stylesheet_directory() . '/ninja-forms/templates/',
         ));
 
         $file_paths[] = Ninja_Forms::$dir . 'includes/Templates/';


### PR DESCRIPTION
Changed output template file path to get_stylesheet_directory() so that template support works out of the box for child themes without needing to add a filter for custom paths.

Fixes #3096 

Changes proposed in this pull request:
- Change output template file path to get_stylesheet_directory() so that template support works out of the box for child themes without needing to add a filter for custom paths. The theme directory is used if no child theme is present. 
-
-

@wpninjas/developers 
