### PR TITLE
fixed Add Form button positioning in post editor when shrinking windo…

### DIFF
--- a/includes/Admin/AddFormModal.php
+++ b/includes/Admin/AddFormModal.php
@@ -38,7 +38,7 @@ class NF_Admin_AddFormModal {
                 margin: 0 2px 0 0;
             }
         </style>';
-        $html .= '<a href="#" class="button-secondary nf-insert-form"><span class="nf-insert-form dashicons dashicons-feedback"></span> ' . __( 'Add Form', 'ninja-forms' ) . '</a>';
+        $html .= '<a href="#" class="button nf-insert-form"><span class="nf-insert-form dashicons dashicons-feedback"></span> ' . __( 'Add Form', 'ninja-forms' ) . '</a>';
 
         wp_enqueue_script( 'nf-combobox', Ninja_Forms::$url . 'assets/js/lib/combobox.min.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-button', 'jquery-ui-autocomplete' ) );
         wp_enqueue_script( 'jBox', Ninja_Forms::$url . 'assets/js/lib/jBox.min.js', array( 'jquery' ) );


### PR DESCRIPTION
…w to a smaller size

Fixes #
This fixed the resizing and text align offset of the Add Form button in the Post editor when resizing the window to a small size

Changes proposed in this pull request:
- Change the class on the a link from 'button-secondary' to just 'button'
-
-

@wpninjas/developers 
