### PR TITLE
Change the submission date format to match the wordpress installs date and time formats.

### DIFF
--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -377,7 +377,12 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
      */
     private function custom_columns_sub_date( $sub )
     {
-        return $sub->get_sub_date( 'm/d/Y h:i A' );
+        // Grab the date and time format options
+        $date_format = get_option( 'date_format' );
+        $time_format = get_option( 'time_format' );
+
+        // Get the sub dates using the date and time formats.
+        return $sub->get_sub_date( $date_format . ' ' . $time_format );
     }
 
     /**

--- a/includes/Database/Models/Submission.php
+++ b/includes/Database/Models/Submission.php
@@ -83,7 +83,7 @@ final class NF_Database_Models_Submission
         return intval( $this->_seq_num );
     }
 
-    public function get_sub_date( $format = 'm/d/Y' )
+    public function get_sub_date( $format )
     {
         return date( $format, strtotime( $this->_sub_date ) );
     }


### PR DESCRIPTION
Fixes #3204 

Changes proposed in this pull request:
-
-
-

@wpninjas/developers 
