### PR TITLE
Check if utf8 methods exist and remove TLS check method

### DIFF
--- a/includes/Admin/Menus/SystemStatus.php
+++ b/includes/Admin/Menus/SystemStatus.php
@@ -123,9 +123,6 @@ final class NF_Admin_Menus_SystemStatus extends NF_Abstracts_Submenu
         elseif( array_key_exists( 'LOCAL_ADDR', $_SERVER ) )
             $server_ip = $_SERVER[ 'LOCAL_ADDR' ];
         $host_name = gethostbyaddr( $server_ip );
-        
-        $tls = WPN_Helper::get_tls();
-        if ( ! $tls ) $tls = 'unknown';
 
         $wp_version = get_bloginfo('version');
         $wp_compatible = ( version_compare( $wp_version, Ninja_Forms::WP_MIN_VERSION ) >= 0 ) ? __( 'Supported', 'ninja-forms' ) : __( 'Not Supported', 'ninja-forms' );
@@ -157,7 +154,6 @@ final class NF_Admin_Menus_SystemStatus extends NF_Abstracts_Submenu
             __( 'WP Version','ninja-forms' ) => $wp_version . ' - ' . $wp_compatible,
             __( 'WP Multisite Enabled','ninja-forms' ) => $multisite,
             __( 'Web Server Info','ninja-forms' ) => esc_html( $_SERVER['SERVER_SOFTWARE'] ),
-            __( 'TLS Version','ninja-forms' ) => $tls,
             __( 'PHP Version','ninja-forms' ) => esc_html( phpversion() ),
             //TODO: Possibly Refactor with Ninja forms global $_db?
             __( 'MySQL Version','ninja-forms' ) => $wpdb->db_version(),

--- a/includes/Dispatcher.php
+++ b/includes/Dispatcher.php
@@ -71,15 +71,11 @@ final class NF_Dispatcher
             $multisite_enabled = 0;
         }
 
-        $tls = WPN_Helper::get_tls();
-        if ( ! $tls ) $tls = 'unknown';
-
         $environment = array(
             'nf_version'                => Ninja_Forms::VERSION,
             'wp_version'                => get_bloginfo('version'),
             'multisite_enabled'         => $multisite_enabled,
             'server_type'               => $_SERVER['SERVER_SOFTWARE'],
-            'tls_version'               => $tls,
             'php_version'               => phpversion(),
             'mysql_version'             => $wpdb->db_version(),
             'wp_memory_limit'           => WP_MEMORY_LIMIT,

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -28,8 +28,10 @@ final class WPN_Helper
     public static function utf8_encode( $input ){
         if ( is_array( $input ) )    {
             return array_map( array( 'self', 'utf8_encode' ), $input );
-        }else{
+        } elseif ( function_exists( 'utf8_encode' ) ) {
             return utf8_encode( $input );
+        } else {
+            return $input;
         }
     }
 
@@ -40,8 +42,10 @@ final class WPN_Helper
     public static function utf8_decode( $input ){
         if ( is_array( $input ) )    {
             return array_map( array( 'self', 'utf8_decode' ), $input );
-        }else{
+        } elseif ( function_exists( 'utf8_decode' ) ){
             return utf8_decode( $input );
+        } else {
+            return $input;
         }
     }
     
@@ -254,46 +258,6 @@ final class WPN_Helper
             return ( $parsed ) ? $parsed : unserialize( $original ); // Fallback if parse error.
         }
         return $original;
-    }
-    
-        
-    /**
-     * Function to get this installation's TLS version
-     * 
-     * Since 3.0
-     * 
-     * @return float OR false
-     */
-    public static function get_tls()
-    {
-        $php_ver = phpversion();
-        // If we have a php version lower than 5.6, bail.
-        if( version_compare( $php_ver, '5.6.0', '<' ) ) return false;
-        // Get the user's TLS version.
-
-        // If we have a php version of 7.0 or higher...
-        if( version_compare( $php_ver, '7.0.0', '>=' ) ) {
-            if( ! function_exists( 'fopen' ) ) return false;
-            $meta = stream_get_meta_data( fopen( 'https://ninjaforms.com/', 'r' ) );
-            $tls = $meta[ 'crypto' ][ 'protocol' ];            
-        }
-        // Otherwise (php version between 5.6 and 7.0)...
-        else {
-            $ctx = stream_context_create( array( 'ssl' => array(
-                'capture_session_meta' => TRUE
-            ) ) );
-            $html = file_get_contents( 'https://ninjaforms.com/', FALSE, $ctx );
-            $meta = stream_context_get_options( $ctx );
-            $tls = $meta[ 'ssl' ][ 'session_meta' ][ 'protocol' ];
-            unset( $ctx );
-        }
-        // If we got a TLS version number...
-        if( false !== strpos( $tls, 'TLSv' ) ) {
-            $ver = substr( $tls, strpos( $tls, 'TLSv' ) + 4 );
-            return floatval( $ver );
-        } else {
-            return false;
-        }
     }
 
     private static function parse_utf8_serialized( $matches )

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -42,7 +42,7 @@ final class WPN_Helper
     public static function utf8_decode( $input ){
         if ( is_array( $input ) )    {
             return array_map( array( 'self', 'utf8_decode' ), $input );
-        } elseif ( function_exists( 'utf8_decode' ) ){
+        } elseif ( function_exists( 'utf8_decode' ) ) {
             return utf8_decode( $input );
         } else {
             return $input;


### PR DESCRIPTION
Fixes #3237 

Changes proposed in this pull request:
- Added function_exists checks for utf8 encode/decode methods in Helper file.
- Removed TLS check, as the fopen call was causing issues on some sites, and the data retrieved by it was not always accurate anyway.

@wpninjas/developers 
