### PR TITLE
Fix the use of deprecated create_function #3242

### DIFF
--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -106,4 +106,13 @@ class NF_Widget extends WP_Widget {
 
 } // class Foo_Widget
 
-add_action( 'widgets_init', create_function( '', 'register_widget( "NF_Widget" );' ) );
+/**
+ * Regiser NF widget
+ *
+ * @see 'widgets_init'
+ */
+function NF_register_widgets() {
+    register_widget( 'NF_Widget' );
+}
+
+add_action( 'widgets_init', 'NF_register_widgets' );

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -107,7 +107,7 @@ class NF_Widget extends WP_Widget {
 } // class Foo_Widget
 
 /**
- * Regiser NF widget
+ * Register NF widget
  *
  * @see 'widgets_init'
  */


### PR DESCRIPTION
Fixes #3242 

Changes proposed in this pull request:
- Create a new function that calls `register_widget` and pass that to `widgets_init` hook.

@wpninjas/developers 
