### PR TITLE
Remove broken handling of invalid date filters

### DIFF
--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -426,7 +426,7 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 
         $begin_date = $_GET[ 'begin_date' ];
         $end_date = $_GET[ 'end_date' ];
-        
+
         // Include submissions on the end_date.
         $end_date = date( 'm/d/Y', strtotime( '+1 day', strtotime( $end_date ) ) );
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -425,7 +425,7 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         if( empty( $_GET[ 'begin_date' ] ) || empty( $_GET[ 'end_date' ] ) ) return $vars;
 
         $begin_date = $_GET[ 'begin_date' ];
-        $end_date = $_GET[ 'end_date' ];
+        $end_date = date( 'r', strtotime( 'tomororw', strtotime( $_GET[ 'end_date' ] ) ) );
 
         if ( ! isset ( $vars['date_query'] ) ) {
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -425,6 +425,8 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         if( empty( $_GET[ 'begin_date' ] ) || empty( $_GET[ 'end_date' ] ) ) return $vars;
 
         $begin_date = $_GET[ 'begin_date' ];
+        $end_date = $_GET[ 'end_date' ];
+        
         // Include submissions on the end_date.
         $end_date = date( 'm/d/Y', strtotime( '+1 day', strtotime( $end_date ) ) );
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -425,7 +425,8 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         if( empty( $_GET[ 'begin_date' ] ) || empty( $_GET[ 'end_date' ] ) ) return $vars;
 
         $begin_date = $_GET[ 'begin_date' ];
-        $end_date = date( 'r', strtotime( 'tomororw', strtotime( $_GET[ 'end_date' ] ) ) );
+        // Include submissions on the end_date.
+        $end_date = date( 'm/d/Y', strtotime( '+1 day', strtotime( $end_date ) ) );
 
         if ( ! isset ( $vars['date_query'] ) ) {
 

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -427,20 +427,12 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         $begin_date = $_GET[ 'begin_date' ];
         $end_date = $_GET[ 'end_date' ];
 
-        // Include submissions on the end_date.
-        $end_date = date( 'm/d/Y', strtotime( '+1 day', strtotime( $end_date ) ) );
-
-        if( $begin_date > $end_date ){
-            $temp_date = $begin_date;
-            $begin_date = $end_date;
-            $end_date = $temp_date;
-        }
-
         if ( ! isset ( $vars['date_query'] ) ) {
 
             $vars['date_query'] = array(
                 'after' => $begin_date,
-                'before' => $end_date
+                'before' => $end_date,
+                'inclusive' => true,
             );
         }
 


### PR DESCRIPTION
Invalid date filters shouldn't be handled by code, and the comparison between date strings doesn't work, as they're not integers.

Remove the extra handling of the next day, WP_Date_Query instead has an `inclusive` param that achieves the required behavior.