### PR TITLE
Decimal setting not honoring 0

### DIFF
--- a/includes/AJAX/Controllers/Submission.php
+++ b/includes/AJAX/Controllers/Submission.php
@@ -230,7 +230,7 @@ class NF_AJAX_Controllers_Submission extends NF_Abstracts_Controller
                 // Scrub unmerged tags (ie deleted/non-existent fields/calcs, etc).
                 $eq = preg_replace( '/{([a-zA-Z0-9]|:|_|-)*}/', 0, $eq);
 
-                $dec = ( isset( $calc[ 'dec' ] ) && ! empty( $calc[ 'dec' ] ) && 0 <= $calc[ 'dec' ] ) ? $calc[ 'dec' ] : 2;
+                $dec = ( isset( $calc[ 'dec' ] ) && 0 <= $calc[ 'dec' ] ) ? $calc[ 'dec' ] : 2;
                 $calcs_merge_tags->set_merge_tags( $calc[ 'name' ], $eq, $dec, $this->_form_data['settings']['decimal_point'], $this->_form_data['settings']['thousands_sep'] );
                 $this->_data[ 'extra' ][ 'calculations' ][ $calc[ 'name' ] ] = array(
                     'raw' => $calc[ 'eq' ],


### PR DESCRIPTION
Fixes #3224 

Changes proposed in this pull request:
- Removed unnecessary check that was causing a 0 value in the decimal place setting to resolve as the default value of 2 instead.


@wpninjas/developers 
