### PR TITLE
Check if global post is set before using it

### DIFF
--- a/includes/Admin/Metaboxes/AppendAForm.php
+++ b/includes/Admin/Metaboxes/AppendAForm.php
@@ -15,7 +15,11 @@ final class NF_Admin_Metaboxes_AppendAForm extends NF_Abstracts_Metabox
 
     public function append_form( $content )
     {
-        $post = isset($GLOBALS['post']) ? $GLOBALS['post'] : NULL;;
+		if ( isset( $GLOBALS[ 'post' ] ) ) {
+			$post = $GLOBALS[ 'post' ];
+		} else {
+			$post = NULL;
+		}
 
         if( ! $post || ! is_object( $post ) ) return $content;
 

--- a/includes/Admin/Metaboxes/AppendAForm.php
+++ b/includes/Admin/Metaboxes/AppendAForm.php
@@ -15,7 +15,7 @@ final class NF_Admin_Metaboxes_AppendAForm extends NF_Abstracts_Metabox
 
     public function append_form( $content )
     {
-        $post = $GLOBALS['post'];
+        $post = isset($GLOBALS['post']) ? $GLOBALS['post'] : NULL;;
 
         if( ! $post || ! is_object( $post ) ) return $content;
 

--- a/includes/Admin/Metaboxes/AppendAForm.php
+++ b/includes/Admin/Metaboxes/AppendAForm.php
@@ -15,11 +15,11 @@ final class NF_Admin_Metaboxes_AppendAForm extends NF_Abstracts_Metabox
 
     public function append_form( $content )
     {
-		if ( isset( $GLOBALS[ 'post' ] ) ) {
-			$post = $GLOBALS[ 'post' ];
-		} else {
-			$post = NULL;
-		}
+        if ( isset( $GLOBALS[ 'post' ] ) ) {
+            $post = $GLOBALS[ 'post' ];
+        } else {
+            $post = NULL;
+        }
 
         if( ! $post || ! is_object( $post ) ) return $content;
 


### PR DESCRIPTION
With some themes editors it can append that there is no post and the current code fires a few php warning like:
PHP Notice:  Undefined index: post in /home1/public_html/test_site/wp-content/plugins/ninja-forms/includes/Admin/Metaboxes/AppendAForm.php on line 18


Fixes #

Changes proposed in this pull request:
- The proposed change is a defense against a non set post.
- Test first if it is set, otherwise set to NULL.

@wpninjas/developers 
