### PR TITLE
Fetch post meta for merge tags on demand, rather than upfront.

### DIFF
--- a/includes/MergeTags/Deprecated.php
+++ b/includes/MergeTags/Deprecated.php
@@ -7,36 +7,10 @@ final class NF_MergeTags_Deprecated extends NF_Abstracts_MergeTags
 {
     protected $id = 'deprecated';
 
-    /**
-     * @var array
-     * $post_meta[ $meta_key ] = $meta_value;
-     */
-    protected $post_meta = array();
-
     public function __construct()
     {
         parent::__construct();
         $this->merge_tags = Ninja_Forms()->config( 'MergeTagsDeprecated' );
-
-        // Setup merge tag data for each post in The Loop.
-        add_action( 'the_post', array( $this, 'init' ) );
-
-        // Setup merge tag data when Doing AJAX.
-        add_action( 'admin_init', array( $this, 'init' ) );
-    }
-
-    public function init()
-    {
-        global $post;
-
-        // If in the admin, only run on Ninja Forms pages.
-        if( is_admin() && ( ! isset( $_GET[ 'page' ] ) || 'ninja-forms' !== $_GET[ 'page' ] ) ) return;
-        
-        $post_id = $this->post_id();
-        
-        if ( ! empty( $post_id ) ) {
-            $this->setup_post_meta( $this->post_id() );
-        }
     }
 
     protected function post_id()
@@ -89,22 +63,6 @@ final class NF_MergeTags_Deprecated extends NF_Abstracts_MergeTags
         if( ! $post ) return '';
         $author = get_user_by( 'id', $post->post_author );
         return $author->user_email;
-    }
-
-    public function setup_post_meta( $post_id )
-    {
-        global $wpdb;
-
-        // Get ALL post meta for a given Post ID.
-        $results = $wpdb->get_results( $wpdb->prepare( "
-            SELECT `meta_key`, `meta_value`
-            FROM {$wpdb->postmeta}
-            WHERE `post_id` = %d
-        ", $post_id ) );
-
-        foreach( $results as $result ){
-            $this->post_meta[ $result->meta_key ] = $result->meta_value;
-        }
     }
 
     protected function user_id()

--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -31,7 +31,7 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
 
         /**
          * Replace Custom Post Meta
-         * {post_meta:_meta_title} --> meta key is 'foo'
+         * {post_meta:foo} --> meta key is 'foo'
          */
         preg_match_all( "/{post_meta:(.*?)}/", $subject, $post_meta_matches );
         if( ! empty( $post_meta_matches[0] ) ) {

--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -7,33 +7,11 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
 {
     protected $id = 'wp';
 
-    /**
-     * @var array
-     * $post_meta[ $meta_key ] = $meta_value;
-     */
-    protected $post_meta = array();
-
     public function __construct()
     {
         parent::__construct();
         $this->title = __( 'WordPress', 'ninja-forms' );
         $this->merge_tags = Ninja_Forms()->config( 'MergeTagsWP' );
-
-        // Setup merge tag data for each post in The Loop.
-        add_action( 'the_post', array( $this, 'init' ) );
-
-        // Setup merge tag data when Doing AJAX.
-        add_action( 'admin_init', array( $this, 'init' ) );
-    }
-
-    public function init()
-    {
-        global $post;
-
-        // If in the admin, only run on Ninja Forms pages.
-        if( is_admin() && ( ! isset( $_GET[ 'page' ] ) || 'ninja-forms' !== $_GET[ 'page' ] ) ) return;
-
-        $this->setup_post_meta( $this->post_id() );
     }
 
     /**
@@ -53,7 +31,7 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
 
         /**
          * Replace Custom Post Meta
-         * {post_meta:foo} --> meta key is 'foo'
+         * {post_meta:_meta_title} --> meta key is 'foo'
          */
         preg_match_all( "/{post_meta:(.*?)}/", $subject, $post_meta_matches );
         if( ! empty( $post_meta_matches[0] ) ) {
@@ -62,9 +40,11 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
              * $matches[1][$i]  captured meta key   foo
              */
             foreach( $post_meta_matches[0] as $i => $search ) {
-                $meta_key = $post_meta_matches[1][$i];
-                if ( isset( $this->post_meta[ $meta_key ] ) ) {
-                    $subject = str_replace( $search, $this->post_meta[$meta_key], $subject );
+                $meta_key   = $post_meta_matches[1][$i];
+                $meta_value = get_post_meta( $this->post_id(), $meta_key, true  );
+
+                if ( $meta_value ) {
+                    $subject = str_replace( $search, $meta_value, $subject );
                 } else {
                     $subject = str_replace( $search, '', $subject );
                 }
@@ -141,22 +121,6 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
         if( ! $post ) return '';
         $author = get_user_by( 'id', $post->post_author );
         return $author->user_email;
-    }
-
-    public function setup_post_meta( $post_id )
-    {
-        global $wpdb;
-
-        // Get ALL post meta for a given Post ID.
-        $results = $wpdb->get_results( $wpdb->prepare( "
-            SELECT `meta_key`, `meta_value`
-            FROM {$wpdb->postmeta}
-            WHERE `post_id` = %d
-        ", $post_id ) );
-
-        foreach( $results as $result ){
-            $this->post_meta[ $result->meta_key ] = $result->meta_value;
-        }
     }
 
     protected function user_id()


### PR DESCRIPTION
Decreases memory use on posts with lots of post meta, and problems caused by some page builders triggering the `the_post` action multiple times to render one screen.

For #3334

Changes proposed in this pull request:
- Fetch post meta on demand, rather than all up-front, for performance improvements (speed and memory).
- Remove an uncached SQL query.

@wpninjas/developers 