### PR TITLE
Added additional check to logic to allow checkboxes to be edited on the edit submission page.

### DIFF
--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -81,14 +81,14 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
         // If the field type is equal to checkbox...
         if( 'checkbox' == $field->get_setting( 'type' ) ) {
             // Backwards compatibility check for the new checked value setting.
-            if( null == $field->get_setting( 'checked_value' ) && 1 == $value ) {
+            if( null == $field->get_setting( 'checked_value' ) && 1 == $value || 'on' == $value ) {
                 return __( 'Checked', 'ninja-forms' );
             } elseif( null == $field->get_setting( 'unchecked_value' ) && 0 == $value ) {
                 return __( 'Unchecked', 'ninja-forms');
             }
 
             // If the field value is set to 1....
-            if( 1 == $value ) {
+            if( 1 == $value || 'on' == $value) {
                 // Set the value to the checked value setting.
                 $value = $field->get_setting( 'checked_value' );
             } else {

--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -54,7 +54,7 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
     public function admin_form_element( $id, $value )
     {
         // If the checkboxes value is one...
-        if( 1 == $value ) {
+        if( 'on' == $value || 1 == $value ) {
             // ...this variable to checked.
             $checked = 'checked';
         } else {

--- a/includes/Fields/Checkbox.php
+++ b/includes/Fields/Checkbox.php
@@ -53,7 +53,7 @@ class NF_Fields_Checkbox extends NF_Abstracts_Input
      */
     public function admin_form_element( $id, $value )
     {
-        // If the checkboxes value is one...
+        // If the checkboxes value is 1 or on...
         if( 'on' == $value || 1 == $value ) {
             // ...this variable to checked.
             $checked = 'checked';


### PR DESCRIPTION
Fixes #3287 

Changes proposed in this pull request:
- Added some additional logic to allow checkboxes to be editable on the edit submissions page. 

@wpninjas/developers 

Replication Steps:
Create a form with a single checkbox, publish, and submit the form. 
Edit the submission, change the value, and update the submission. On the current version of master 
the value shouldn't be updated. On this branch the update feature will work properly. 