### PR TITLE
fixes decimal issues

### DIFF
--- a/includes/AJAX/Controllers/Submission.php
+++ b/includes/AJAX/Controllers/Submission.php
@@ -237,7 +237,13 @@ class NF_AJAX_Controllers_Submission extends NF_Abstracts_Controller
                 // Scrub unmerged tags (ie deleted/non-existent fields/calcs, etc).
                 $eq = preg_replace( '/{([a-zA-Z0-9]|:|_|-)*}/', 0, $eq);
 
-                $dec = ( isset( $calc[ 'dec' ] ) && 0 <= $calc[ 'dec' ] ) ? $calc[ 'dec' ] : 2;
+				/**
+				 * PHP doesn't evaluate empty strings to numbers. So check
+	             * for any string for the decimal place
+				**/
+                $dec = ( isset( $calc[ 'dec' ] ) && '' != $calc[ 'dec' ] ) ?
+	                $calc[ 'dec' ] : 2;
+                
                 $calcs_merge_tags->set_merge_tags( $calc[ 'name' ], $eq, $dec, $this->_form_data['settings']['decimal_point'], $this->_form_data['settings']['thousands_sep'] );
                 $this->_data[ 'extra' ][ 'calculations' ][ $calc[ 'name' ] ] = array(
                     'raw' => $calc[ 'eq' ],


### PR DESCRIPTION
I don't think there was an issue created for this

Create a calculation. Set decimal field to empty, and the calculation should show with 2 decimal places. Try changing it to 0 and 2 and back to nothing. Make sure it works in each scenario. Make sure Paypal and Stripe actions work.


@wpninjas/developers 
