### PR TITLE
added check to make sure the form id is numeric

### DIFF
--- a/includes/Display/Preview.php
+++ b/includes/Display/Preview.php
@@ -48,7 +48,17 @@ final class NF_Display_Preview
     {
         if ( ! is_user_logged_in() ) return __( 'You must be logged in to preview a form.', 'ninja-forms' );
 
-	    if( ! is_numeric( $this->_form_id ) ) {
+        // takes into account if we are trying to preview a non-published form
+        $tmp_id_test = explode( '-', $this->_form_id );
+
+        // if only 1 element, then is it numeric
+	    if( 1 === count( $tmp_id_test) && ! is_numeric( $tmp_id_test[ 0 ] ) ) {
+		    return __( 'You must provide a valid form ID.', 'ninja-forms' );
+	    }
+	    // if 2 array elements, is the first equal to 'tmp' and the second numeric
+	    elseif ( ( 2 === count( $tmp_id_test )
+	                 && ('tmp' != $tmp_id_test[ 0 ]
+                     || ! is_numeric( $tmp_id_test[ 1 ] ) ) ) ) {
 		    return __( 'You must provide a valid form ID.', 'ninja-forms' );
 	    }
 

--- a/includes/Display/Preview.php
+++ b/includes/Display/Preview.php
@@ -48,6 +48,10 @@ final class NF_Display_Preview
     {
         if ( ! is_user_logged_in() ) return __( 'You must be logged in to preview a form.', 'ninja-forms' );
 
+	    if( ! is_numeric( $this->_form_id ) ) {
+		    return __( 'You must provide a valid form ID.', 'ninja-forms' );
+	    }
+
         return do_shortcode( "[nf_preview id='{$this->_form_id}']" );
     }
 


### PR DESCRIPTION
Fixes #3384 

Changes proposed in this pull request:
- check the url parameter 'nf_preview_form' for a numeric value, or throw warning.
- to test, you can add a short code to the url like:

http://test.dev?nf_preview_form=1'][video src='video-source.mp4

@wpninjas/developers 
