### PR TITLE
Gutenberg changes - block icon

### DIFF
--- a/assets/js/min/block.js
+++ b/assets/js/min/block.js
@@ -7,7 +7,7 @@
 	// Register our Gutenberg block
 	blocks.registerBlockType( 'ninja-forms/forms', {
 		title: 'Ninja Forms',
-		icon: 'edit',
+		icon: 'feedback',
 		category: 'common',
 		attributes: {
 			nf_form_id: {


### PR DESCRIPTION
Change the 'edit' icon currently in use to the 'feedback' icon to be more consistent with the core Ninja Forms plugin icons

@wpninjas/developers 
