### PR TITLE
added logged in check to custom meta merge tag. 

### DIFF
--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -71,12 +71,14 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
             }
         }
 
+        // Check to ensure our user is logged in. If not don't return.
+        if( is_user_logged_in() ) {
         /**
          * Replace Custom User Meta
          * {user_meta:foo} --> meta key is 'foo'
          */
         preg_match_all( "/{user_meta:(.*?)}/", $subject, $user_meta_matches );
-        if( ! empty( $user_meta_matches[0] ) && $user_id = get_current_user_id() ) {
+        if( ! empty( $user_meta_matches[0] ) && $user_id = get_current_user_id()  ) {
             /**
              * $matches[0][$i]  merge tag match     {user_meta:foo}
              * $matches[1][$i]  captured meta key   foo
@@ -87,8 +89,8 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
                 $subject = str_replace( $search, $meta_value, $subject );
             }
         }
-
-      return parent::replace( $subject );
+        return parent::replace( $subject );
+        }
     }
 
     protected function post_id()


### PR DESCRIPTION
Fixes #3192 

Changes proposed in this pull request:
- added logged in check to custom meta merge tag. 

@wpninjas/developers 

Replication Steps: 
Make sure your profile has data on the first name(it's under Users->Your Profile in WordPress). 
Create a form with a first name field, add this merge tag {user_meta:first_name}. 
Put your form on a post/page then view it in an incognito window or logout. There you'll see the merge tag is still visible. 
Switch to this branch and reload the page. 
