### PR TITLE
fixes not being able to edit label for star rating fields

### DIFF
--- a/includes/Config/FieldSettings.php
+++ b/includes/Config/FieldSettings.php
@@ -784,7 +784,7 @@ return apply_filters( 'ninja_forms_field_settings', array(
         'type' => 'textbox',
         'value' => 5,
         'label' => __( 'Number of stars', 'ninja-forms' ),
-        'width' => '',
+        'width' => 'full',
         'group' => '',
 
     ),


### PR DESCRIPTION
Fixes #3396 

Changes proposed in this pull request:
- You should be able to edit the star rating field's label now

@wpninjas/developers 
