### PR TITLE
Removed if check from around custom user meta merge tag. This resolves the issue with actions not firing while users are logged out.

### DIFF
--- a/includes/MergeTags/WP.php
+++ b/includes/MergeTags/WP.php
@@ -70,9 +70,6 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
                 }
             }
         }
-
-        // Check to ensure our user is logged in. If not don't return.
-        if( is_user_logged_in() ) {
         /**
          * Replace Custom User Meta
          * {user_meta:foo} --> meta key is 'foo'
@@ -90,7 +87,6 @@ final class NF_MergeTags_WP extends NF_Abstracts_MergeTags
             }
         }
         return parent::replace( $subject );
-        }
     }
 
     protected function post_id()


### PR DESCRIPTION
Fixes #3401 

Changes proposed in this pull request:
- Actions will now fire for logged out users 


@wpninjas/developers 

Replication Steps: 
Submit a form as a user who is logged out. 
Check the AJAX response actions will not fire. 
Switch to this branch and retry the same test. 