### PR TITLE
MOD: show ListCheckbox submission as bullet list in emails

### DIFF
--- a/includes/MergeTags/Fields.php
+++ b/includes/MergeTags/Fields.php
@@ -47,7 +47,7 @@ final class NF_MergeTags_Fields extends NF_Abstracts_MergeTags
 
             $field[ 'value' ] = apply_filters( 'ninja_forms_merge_tag_value_' . $field[ 'type' ], $field[ 'value' ], $field );
 
-            if( is_array( $field[ 'value' ] ) ) $field[ 'value' ] = implode( ', ', $field[ 'value' ] );
+            if( is_array( $field[ 'value' ] ) ) $field[ 'value' ] = "<ul><li>".implode( '</li><li>', $field[ 'value' ] )."</li></ul>";
 
             $return .= '<tr><td>' . apply_filters('ninja_forms_merge_label', $field[ 'label' ]) .':</td><td>' . $field[ 'value' ] . '</td></tr>';
         }
@@ -142,7 +142,7 @@ final class NF_MergeTags_Fields extends NF_Abstracts_MergeTags
         $field_id  = $field[ 'id' ];
         $callback  = 'field_' . $field_id;
 
-        if( is_array( $field[ 'value' ] ) ) $field[ 'value' ] = implode( ',', $field[ 'value' ] );
+        if( is_array( $field[ 'value' ] ) ) $field[ 'value' ] = "<ul><li>".implode( '</li><li>', $field[ 'value' ] )."</li></ul>";
 
         $field[ 'value' ] = strip_shortcodes( $field[ 'value' ] );
 


### PR DESCRIPTION
Fixes #3415

Changes proposed in this pull request:

- Modified the NF_MergeTags_Fields Class to display ListCheckbox input submissions as bullets rather than an array of strings. I think a bullet list is much easier to read if the values are longer than a single word. 

NOTE: I had to make a new branch "issue/3415b" because for ""issue/3415" I branched off from a previous bug fix I did regarding issue #3261. Please delete branch "issue/3415". 

@wpninjas/developers 
