### PR TITLE
deactivate and delete large cache fix

### DIFF
--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -696,7 +696,7 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
 					    if (is_dir($dir.$obj))
 					    {
 						    // recursively delete the directories
-						    if (!deleteDir($dir.$obj))
+						    if (! $this->deleteDir($dir.$obj))
 							    return false;
 					    }
 					    elseif (is_file($dir.$obj))


### PR DESCRIPTION
This deactivates Kyle's large cache fix and deletes the files. We are going to implement something similar

https://github.com/kjohnson/nf-large-cache-fix

@wpninjas/developers 
