### PR TITLE
Fixes the _Drop method's query so it targets the correct tables to be dropped

### DIFF
--- a/includes/Abstracts/Migration.php
+++ b/includes/Abstracts/Migration.php
@@ -46,7 +46,7 @@ abstract class NF_Abstracts_Migration
         global $wpdb;
         if( ! $this->table_name ) return;
         if( 0 == $wpdb->query( $wpdb->prepare( "SHOW TABLES LIKE '%s'", $this->table_name() ) ) ) return;
-        $wpdb->query( $wpdb->prepare( "DROP TABLE %s", $this->table_name() ) );
+        $wpdb->query( $wpdb->prepare( "DROP TABLE " . $this->table_name() ) );
         return $this->drop();
     }
 

--- a/includes/Abstracts/Migration.php
+++ b/includes/Abstracts/Migration.php
@@ -46,7 +46,7 @@ abstract class NF_Abstracts_Migration
         global $wpdb;
         if( ! $this->table_name ) return;
         if( 0 == $wpdb->query( $wpdb->prepare( "SHOW TABLES LIKE '%s'", $this->table_name() ) ) ) return;
-        $wpdb->query( $wpdb->prepare( "DROP TABLE " . $this->table_name() ) );
+        $wpdb->query( "DROP TABLE " . $this->table_name() );
         return $this->drop();
     }
 


### PR DESCRIPTION
Fixes #3372

Changes proposed in this pull request:
- Fixes the _Drop method's query so it targets the correct tables to be dropped.
- This also may fix our nuke DB method. For some reason our folder wasn't being removed on delete, I'm looking into this now. 

@wpninjas/developers 

Replication steps: 
(on master)Create two forms in 3.0, roll back to 2.9.x. Create 1 form. Run the conversion process at least one of your forms will still be left over. 

(switch to this branch)Do the same steps except now after conversion the only forms you'll have left is the ones that were converted. 