### PR TITLE
fixes issue 3228 where upgrading messes up field id sequencing

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -95,6 +95,7 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             if( $is_conversion ) {
                 $field_id = $settings[ 'id' ];
                 $field = Ninja_Forms()->form($form_id)->field( $field_id )->get();
+                $field->save();
             } else {
                 unset( $settings[ 'id' ] );
                 $settings[ 'created_at' ] = current_time( 'mysql' );


### PR DESCRIPTION
Fixes #3228

field save was removed a while back and this created inconsistencies in field id sequencing making some fields added AFTER upgrading to NOT show up in the builder

@wpninjas/developers 
