### PR TITLE
Removed the word submissions from both the completed submission link and the trashed submission link on the submissions page.

### DIFF
--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -85,10 +85,10 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 
         // Build our new views.
         $views[ 'all' ] = '<a href="' . admin_url( 'edit.php?post_status=all&post_type=nf_sub'  ) . $form_id . '">'
-                        . __( 'Completed Submissions', 'ninja-forms' ) . '</a>';
+                        . __( 'Completed', 'ninja-forms' ) . '</a>';
 
         $views[ 'trash' ] = '<a href="' . admin_url( 'edit.php?post_status=trash&post_type=nf_sub' ) . $form_id . '">'
-                            . __( 'Trashed Submissions', 'ninja-forms' ) . '</a>';
+                            . __( 'Trashed', 'ninja-forms' ) . '</a>';
 
         // Checks to make sure we have a post status.
         if( ! empty( $_GET[ 'post_status' ] ) ) {

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -94,9 +94,9 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
         if( ! empty( $_GET[ 'post_status' ] ) ) {
             // Depending on the domain set the value to plain text.
             if ( 'all' == $_GET[ 'post_status' ] ) {
-                $views[ 'all' ] = __( 'Completed Submissions', 'ninja-forms' );
+                $views[ 'all' ] = __( 'Completed', 'ninja-forms' );
             } else if ( 'trash' == $_GET[ 'post_status' ] ) {
-                $views[ 'trash' ] = __( 'Trashed Submissions', 'ninja-forms' );
+                $views[ 'trash' ] = __( 'Trashed', 'ninja-forms' );
             }
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed the word submissions from both the completed submission link and the trashed submission link on the submissions page.


@wpninjas/developers 

Go to the submissions edit screen and the word submissions will be removed form the links in the cpt. 