### PR TITLE
fixed issue where hyphens broke calculations in submissions edit view

### DIFF
--- a/includes/MergeTags/Fields.php
+++ b/includes/MergeTags/Fields.php
@@ -256,7 +256,8 @@ final class NF_MergeTags_Fields extends NF_Abstracts_MergeTags
 
     public function pre_parse_calc_settings( $eq )
     {
-        return preg_replace_callback( '/{field:([a-z0-9]|_)*}/', array( $this, 'force_field_calc_tags' ), $eq );
+        return preg_replace_callback( '/{field:([a-z0-9]|_|-)*}/',
+	        array( $this, 'force_field_calc_tags' ), $eq );
     }
 
     private function force_field_calc_tags( $matches )


### PR DESCRIPTION
Fixes #3193 

Changes proposed in this pull request:
- Made change to regular expression to include hyphens so that calc with field keys containing hyphens wouldn't break in submissions edit view

@wpninjas/developers 
