### PR TITLE
fixes infinite loops and typos

### DIFF
--- a/includes/Admin/Processes/ChunkPublish.php
+++ b/includes/Admin/Processes/ChunkPublish.php
@@ -45,7 +45,7 @@ class NF_Admin_Processes_ChunkPublish extends NF_Abstracts_BatchProcess
     public function process()
     {
         // If we were told this is a new publish...
-        if ( $this->$data[ 'new_publish' ] ) {
+        if ( $this->data[ 'new_publish' ] === 'true' ) {
             // Delete our option to reset the process.
             $this->remove_option();
         }
@@ -282,6 +282,7 @@ class NF_Admin_Processes_ChunkPublish extends NF_Abstracts_BatchProcess
             $sql = "DELETE FROM `" . $wpdb->prefix . "options` WHERE option_name LIKE 'nf_form_" . $this->form_id . "_publishing_%'";
             $wpdb->query( $sql );
         }
+        $this->data[ 'new_publish' ] = 'false';
     }
 
 }


### PR DESCRIPTION
We found some typos causing errors and an infinite loops once we fixed that typo.

Should be working now.

@wpninjas/developers 
