### PR TITLE
fix php notice on form export

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -344,7 +344,8 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             header( 'Pragma: no-cache');
             header( 'Expires: 0' );
 //            echo apply_filters( 'ninja_forms_form_export_bom',"\xEF\xBB\xBF" ) ; // Byte Order Mark
-	        if( $_REQUEST[ 'nf_export_form_turn_off_encoding' ] ) {
+	        if( isset( $_REQUEST[ 'nf_export_form_turn_off_encoding' ] )
+	            && $_REQUEST[ 'nf_export_form_turn_off_encoding' ] ) {
 		        echo json_encode( $export );
 	        } else {
 		        echo json_encode( WPN_Helper::utf8_encode( $export ) );


### PR DESCRIPTION
Fixes a PHP notice on some instances when export a form and leaving the 'turn off utf-8 encoding' box is unchecked

@wpninjas/developers 
