### PR TITLE
Plain Text Email Conversion

### DIFF
--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -512,7 +512,11 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             $action[ 'email_subject' ] 	= str_replace( '`', ',', $action[ 'email_subject' ] );
             $action[ 'cc' ] 		= str_replace( '`', ',', $action[ 'cc' ] );
             $action[ 'bcc' ] 		= str_replace( '`', ',', $action[ 'bcc' ] );
-            $action[ 'email_message' ] = nl2br( $action[ 'email_message' ] );
+            if ( $action[ 'email_format' ] == 'plain' ) {
+                $action[ 'email_message_plain' ] = $action[ 'email_message' ];
+            } else {
+                $action[ 'email_message' ] = nl2br( $action[ 'email_message' ] );
+            }
         }
 
         // Convert `name` to `label`

--- a/includes/Database/Models/Form.php
+++ b/includes/Database/Models/Form.php
@@ -512,9 +512,13 @@ final class NF_Database_Models_Form extends NF_Abstracts_Model
             $action[ 'email_subject' ] 	= str_replace( '`', ',', $action[ 'email_subject' ] );
             $action[ 'cc' ] 		= str_replace( '`', ',', $action[ 'cc' ] );
             $action[ 'bcc' ] 		= str_replace( '`', ',', $action[ 'bcc' ] );
+            // If our email is in plain text...
             if ( $action[ 'email_format' ] == 'plain' ) {
+                // Record it as such.
                 $action[ 'email_message_plain' ] = $action[ 'email_message' ];
-            } else {
+            } // Otherwise... (It's not plain text.)
+            else {
+                // Record it as HTML.
                 $action[ 'email_message' ] = nl2br( $action[ 'email_message' ] );
             }
         }


### PR DESCRIPTION
Fixes #3519

Changes proposed in this pull request:
- Added check to record email contents as plain text if specified or HTML by default upon conversion of action.

@wpninjas/developers 
