### PR TITLE
Override admin templates

### DIFF
--- a/includes/Display/Render.php
+++ b/includes/Display/Render.php
@@ -631,7 +631,7 @@ final class NF_Display_Render
             get_stylesheet_directory() . '/ninja-forms/templates/',
         ));
 
-        $file_paths[] = Ninja_Forms::$dir . 'includes/Templates/';
+        $file_paths = array_merge( $file_paths, Ninja_Forms::get_template_paths() );
 
         // Search for and Output File Templates
         foreach( self::$loaded_templates as $file_name ) {

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -686,6 +686,24 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
          */
 
         /**
+	     * Obtain all possible template paths.
+	     * 
+	     * @return mixed|null|array
+	     */
+        public static function get_template_paths() {
+        	static $template_paths = null;
+
+        	if ( is_null( $template_paths ) ) {
+		        $template_paths = apply_filters( 'ninja_forms_template_file_paths', array(
+				        self::$dir . 'includes/Templates/',
+			        )
+		        );
+	        }
+
+        	return $template_paths;
+        }
+
+        /**
          * Template
          *
          * @param string $file_name
@@ -697,13 +715,22 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
 
             extract( $data );
 
-            $path = self::$dir . 'includes/Templates/' . $file_name;
+	        $file_path = '';
 
-            if( ! file_exists( $path ) ) return FALSE;
+            foreach ( self::get_template_paths() as $path ) {
+            	if ( ! file_exists( $path . $file_name ) ) {
+            		continue;
+	            }
 
-            if( $return ) return file_get_contents( $path );
+	            $file_path = $path . $file_name;
+            	break;
+            }
 
-            include $path;
+            if( ! file_exists( $file_path ) ) return FALSE;
+
+            if( $return ) return file_get_contents( $file_path );
+
+            include $file_path;
         }
 
         /**


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow overriding admin templates from other plugins. Right now, templates loaded using `Ninja_Forms::template()` directly can only be inside `ninja-forms/includes/Templates`, which makes it hard to extend or customize the admin UI.
- Add a `Ninja_Forms::get_template_paths()` method, which returns an array containing all the available template paths. This list can be modified using the `ninja_forms_template_file_paths` filter.
- Implement `Ninja_Forms::get_template_paths()` inside `NF_Render::output_templates()`, so this new list can work together with the `ninja_forms_field_template_file_paths` filter, which already allows to override field templates in the public side.

Quick implementation example:

```php
add_filter( 'ninja_forms_template_file_paths', 'my_plugin_add_template_paths' );
my_plugin_add_template_paths( array $paths ) {
	$new_paths = array(
		'/path/to/my-plugin/templates',
		'/path/to/other-plugin/templates',
	);

	return array_merge( $new_paths, $paths );
}
```

@wpninjas/developers 
