### PR TITLE
Issue#3530

### DIFF
--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -120,7 +120,7 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 	 * enqueue scripts here
 	 */
 	public function enqueue_scripts() {
-
+		// let's check and make sure we're on the submissions page.
 		if( isset( $_GET[ 'post_type' ] ) && 'nf_sub' == $_GET[ 'post_type' ]
 			&& $_SERVER[ 'DOCUMENT_URI'] == '/wp-admin/edit.php' ) {
 			wp_enqueue_style( 'nf-admin-settings', Ninja_Forms::$url . 'assets/css/admin-settings.css' );

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -120,12 +120,16 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 	 * enqueue scripts here
 	 */
 	public function enqueue_scripts() {
-		wp_enqueue_style( 'nf-admin-settings', Ninja_Forms::$url . 'assets/css/admin-settings.css' );
 
-		wp_register_script( 'ninja_forms_admin_submissions',
-			Ninja_Forms::$url . 'assets/js/admin-submissions.js', array( 'jquery' ), FALSE, TRUE );
+		if( isset( $_GET[ 'post_type' ] ) && 'nf_sub' == $_GET[ 'post_type' ]
+			&& $_SERVER[ 'DOCUMENT_URI'] == '/wp-admin/edit.php' ) {
+			wp_enqueue_style( 'nf-admin-settings', Ninja_Forms::$url . 'assets/css/admin-settings.css' );
 
-		wp_enqueue_script( 'ninja_forms_admin_submissions' );
+			wp_register_script( 'ninja_forms_admin_submissions',
+				Ninja_Forms::$url . 'assets/js/admin-submissions.js', array( 'jquery' ), false, true );
+
+			wp_enqueue_script( 'ninja_forms_admin_submissions' );
+		}
 	}
     /**
      * Change Columns

--- a/includes/Admin/Menus/Submissions.php
+++ b/includes/Admin/Menus/Submissions.php
@@ -121,8 +121,10 @@ final class NF_Admin_Menus_Submissions extends NF_Abstracts_Submenu
 	 */
 	public function enqueue_scripts() {
 		// let's check and make sure we're on the submissions page.
+		$test = strpos( $_SERVER[ 'REQUEST_URI' ], '/wp-admin/edit.php' );
 		if( isset( $_GET[ 'post_type' ] ) && 'nf_sub' == $_GET[ 'post_type' ]
-			&& $_SERVER[ 'DOCUMENT_URI'] == '/wp-admin/edit.php' ) {
+			&& -1 < strpos( $_SERVER[ 'REQUEST_URI' ], '/wp-admin/edit.php' )
+	) {
 			wp_enqueue_style( 'nf-admin-settings', Ninja_Forms::$url . 'assets/css/admin-settings.css' );
 
 			wp_register_script( 'ninja_forms_admin_submissions',


### PR DESCRIPTION
Fixes #3530

Changes proposed in this pull request:
- limits admin-submissions.js to only load on the Submissions page, thus keeping it from breaking mousedown on other pages.


@wpninjas/developers 
