### PR TITLE
Db tracker

### DIFF
--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -4,7 +4,7 @@ This document describes the architecture of the Ninja Forms database layer.
 ## Version 1.0
 
 ### Forms
-
+```
 _**nf3_forms**_ (Table of individual Forms)
 * id (The unique ID of the Form)
   * int(11)
@@ -28,8 +28,8 @@ _**nf3_forms**_ (Table of individual Forms)
   * int(11)
 * subs (The Form's number of lifetime Submissions)
   * int(11)
-
-
+```
+```
 _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
 * id (The unique ID of the Setting)
   * int(11)
@@ -47,9 +47,9 @@ _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-
+```
 ### Fields
-
+```
 _**nf3_fields**_ (Table of individual Fields)
 * id (The unique ID of the Field)
   * int(11)
@@ -76,8 +76,8 @@ _**nf3_fields**_ (Table of individual Fields)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Field was last updated)
   * datetime
-
-
+```
+```
 _**nf3_field_meta**_ (Table of Settings associated with each Field)
 * id (The unique ID of the Setting)
   * int(11)
@@ -95,9 +95,9 @@ _**nf3_field_meta**_ (Table of Settings associated with each Field)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-  
+```
 ### Actions
-
+```
 _**nf3_actions**_ (Table of individual Actions)
 * id (The unique ID of the Action)
   * int(11)
@@ -127,8 +127,8 @@ _**nf3_actions**_ (Table of individual Actions)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Action was last updated)
   * datetime
-
-
+```
+```
 _**nf3_action_meta**_ (Table of Settings associated with each Action)
 * id (The unique ID of the Setting)
   * int(11)
@@ -146,3 +146,110 @@ _**nf3_action_meta**_ (Table of Settings associated with each Action)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
+```
+### Objects
+```
+_**nf3_objects**_ (Table of non-structured Objects)
+* id (The unique ID of the Object)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primrary Key
+* type (The type of Object this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* title (The displayable title of the Object)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* created_at (The date/time the Object was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Object was last updated)
+  * datetime
+```
+```
+_**nf3_object_meta**_ (Table of Settings associated with each Object)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* parent_id (The Object ID this Setting is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+```
+```
+_**nf3_relationships**_ (Table of Relationships between Objects)
+* id (The unique ID of the Relationship)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* child_id (The child Object ID this record is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* child_type (The type of Object represented by child_id)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* parent_id (The parent Object ID this record is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* parent_type (The type of Object represented by parent_id)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* created_at (The date/time the Relationship was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Relationship was last updated)
+  * datetime
+```
+```
+_**options**_ (The default WordPress options table)
+* option_name = 'nf_form_%' WHERE % = *nf3_forms* id
+* option_value = Serialized JSON Object (The Ninja Forms Cache)
+```
+### Submissions
+```
+_**posts**_ (The default WordPress posts table)
+* id (The unique ID of the Post)
+  * bigint(20)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* post_type = 'nf_sub'
+```
+```
+_**postmeta**_ (The default WordPress postmeta table)
+* meta_id (The unique ID of the Metadata)
+  * bigint(20)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* post_id (The Post ID this Metadata is associated with)
+  * bigint(20)
+  * NOT NULL
+  * DEFAULT 0
+  * Foreign Key ON *posts* id
+* meta_key (The identifiable key by which this record is referenced)
+  * varchar(255)
+  * COLLATE DATABASE_DEFAULT
+* meta_value (The value of this record)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+```

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -1,0 +1,49 @@
+## Description
+This document describes the architecture of the Ninja Forms database layer.
+
+### Version 1.0
+
+**Forms**
+
+*nf3_forms*
+* id
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* title
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* created_at
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at
+  * datetime
+* views
+  * int(11)
+*subs
+  * int(11)
+
+*nf3_form_meta*
+* id
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* parent_id
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* key
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -1,11 +1,11 @@
 ## Description
 This document describes the architecture of the Ninja Forms database layer.
 
-### Version 1.0
+## Version 1.0
 
-**Forms**
+### Forms
 
-*nf3_forms*
+_**nf3_forms**_
 * id
   * int(11)
   * NOT NULL
@@ -26,10 +26,10 @@ This document describes the architecture of the Ninja Forms database layer.
   * datetime
 * views
   * int(11)
-*subs
+* subs
   * int(11)
 
-*nf3_form_meta*
+_**nf3_form_meta**_
 * id
   * int(11)
   * NOT NULL

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -5,45 +5,45 @@ This document describes the architecture of the Ninja Forms database layer.
 
 ### Forms
 
-_**nf3_forms**_
-* id
+_**nf3_forms**_ (Table of individual Forms)
+* id (The unique ID of the Form)
   * int(11)
   * NOT NULL
   * AUTO_INCREMENT
   * Primary Key
-* title
+* title (The displayable title of the Form)
   * longtext
   * COLLATE DATABASE_DEFAULT
-* key
+* key (The administrative key of the Form)
   * longtext
   * COLLATE DATABASE_DEFAULT
-* created_at
+* created_at (The date/time the Form was created)
   * timestamp
   * NOT NULL
   * DEFAULT CURRENT_TIMESTAMP
   * ON UPDATE CURRENT_TIMESTAMP
-* updated_at
+* updated_at (The date/time the Form was last updated)
   * datetime
-* views
+* views (The number of times the Form has been viewed)
   * int(11)
-* subs
+* subs (The Form's number of lifetime Submissions)
   * int(11)
 
-_**nf3_form_meta**_
-* id
+_**nf3_form_meta**_ (Table of Settings assoicated with each Form)
+* id (The unique ID of the Setting)
   * int(11)
   * NOT NULL
   * AUTO_INCREMENT
   * Primary Key
-* parent_id
+* parent_id (The Form ID this Setting is associated with)
   * int(11)
   * NOT NULL
   * Foreign Key ON *nf3_forms* id
-* key
+* key (The administrative key of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
   * NOT NULL
-* value
+* value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
 

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -1,7 +1,10 @@
 ## Description
+
 This document describes the architecture of the Ninja Forms database layer.
 
-## Version 1.0
+## Current Structure (1.1)
+
+This section contains the current structure of the Ninja Forms data layer and is updated each time that structure changes. For legacy data, please see the individual version notes.
 
 ### Forms
 
@@ -252,3 +255,291 @@ _**postmeta**_ (The default WordPress postmeta table)
 * meta_value (The value of this record)
   * longtext
   * COLLATE DATABASE_DEFAULT
+
+### Upgrades
+
+_**nf3_upgrades**_ (Table of Forms as they exist in the current structure and the stage of upgrade currently applied to each Form)
+* id (The unique ID of the Form)
+  * int(11)
+  * NOT NULL
+  * Primary Key
+* cache (The Ninja Forms cache as it was retrieved from the *options* table)
+  * longtext
+  * COLLATE utf8mb4_general_ci (fallback to utf8_general_ci)
+* stage (The current upgrade stage of the Form)
+  * int(11)
+  * NOT NULL
+  * DEFAULT 0
+
+## Version 1.0
+
+Defined initial structure for Ninja Forms data layer.
+
+### Forms
+
+_**nf3_forms**_ (Table of individual Forms)
+* id (The unique ID of the Form)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* title (The displayable title of the Form)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key (The administrative key of the Form)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* created_at (The date/time the Form was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Form was last updated)
+  * datetime
+* views (The number of times the Form has been viewed)
+  * int(11)
+* subs (The Form's number of lifetime Submissions)
+  * int(11)
+
+
+_**nf3_form_meta**_ (Table of Settings assoicated with each Form)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* parent_id (The Form ID this Setting is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+
+### Fields
+
+_**nf3_fields**_ (Table of individual Fields)
+* id (The unique ID of the Field)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* label (The displayable label of the Field)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key (The administrative key of the Field)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* type (The type of Field this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* parent_id (The Form ID this Field is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* created_at (The date/time the Field was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Field was last updated)
+  * datetime
+
+
+_**nf3_field_meta**_ (Table of Settings associated with each Field)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* parent_id (The Field ID this Setting is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_fields* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  
+### Actions
+
+_**nf3_actions**_ (Table of individual Actions)
+* id (The unique ID of the Action)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primrary Key
+* title (The displayable title of the Action)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key (The administrative key of the Action)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* type (The type of Action this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* active (Whether or not the Action is active)
+  * tinyint(1)
+  * DEFAULT 1
+* parent_id (The Form ID this Action is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* created_at (The date/time the Action was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Action was last updated)
+  * datetime
+
+
+_**nf3_action_meta**_ (Table of Settings associated with each Action)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* parent_id (The Action ID this Setting is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_actions* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+
+### Objects
+
+_**nf3_objects**_ (Table of non-structured Objects)
+* id (The unique ID of the Object)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primrary Key
+* type (The type of Object this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* title (The displayable title of the Object)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* created_at (The date/time the Object was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Object was last updated)
+  * datetime
+
+
+_**nf3_object_meta**_ (Table of Settings associated with each Object)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* parent_id (The Object ID this Setting is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+
+
+_**nf3_relationships**_ (Table of Relationships between Objects)
+* id (The unique ID of the Relationship)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* child_id (The child Object ID this record is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* child_type (The type of Object represented by child_id)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* parent_id (The parent Object ID this record is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_objects* id
+* parent_type (The type of Object represented by parent_id)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* created_at (The date/time the Relationship was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Relationship was last updated)
+  * datetime
+
+
+_**options**_ (The default WordPress options table)
+* option_name = 'nf_form_%' WHERE % = *nf3_forms* id
+* option_value = Serialized JSON Object (The Ninja Forms Cache)
+
+### Submissions
+
+_**posts**_ (The default WordPress posts table)
+* id (The unique ID of the Post)
+  * bigint(20)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* post_type = 'nf_sub'
+
+
+_**postmeta**_ (The default WordPress postmeta table)
+* meta_id (The unique ID of the Metadata)
+  * bigint(20)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* post_id (The Post ID this Metadata is associated with)
+  * bigint(20)
+  * NOT NULL
+  * DEFAULT 0
+  * Foreign Key ON *posts* id
+* meta_key (The identifiable key by which this record is referenced)
+  * varchar(255)
+  * COLLATE DATABASE_DEFAULT
+* meta_value (The value of this record)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+
+## Version 1.1
+
+Defined tracker table for data structure updates.
+
+### Upgrades
+
+_**nf3_upgrades**_ (Table of Forms as they exist in the current structure and the stage of upgrade currently applied to each Form)
+* id (The unique ID of the Form)
+  * int(11)
+  * NOT NULL
+  * Primary Key
+* cache (The Ninja Forms cache as it was retrieved from the *options* table)
+  * longtext
+  * COLLATE utf8mb4_general_ci (fallback to utf8_general_ci)
+* stage (The current upgrade stage of the Form)
+  * int(11)
+  * NOT NULL
+  * DEFAULT 0

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -95,3 +95,54 @@ _**nf3_field_meta**_ (Table of Settings associated with each Field)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
+  
+### Actions
+
+_**nf3_actions**_ (Table of individual Actions)
+* id (The unique ID of the Action)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primrary Key
+* title (The displayable title of the Action)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key (The administrative key of the Action)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* type (The type of Action this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* active (Whether or not the Action is active)
+  * tinyint(1)
+  * DEFAULT 1
+* parent_id (The Form ID this Action is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* created_at (The date/time the Action was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Action was last updated)
+  * datetime
+
+
+_**nf3_action_meta**_ (Table of Settings associated with each Action)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary KEY
+* parent_id (The Action ID this Setting is associated with)
+  * int(11)
+  * NOT_NULL
+  * Foreign Key ON *nf3_actions* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -4,7 +4,7 @@ This document describes the architecture of the Ninja Forms database layer.
 ## Version 1.0
 
 ### Forms
-```
+
 _**nf3_forms**_ (Table of individual Forms)
 * id (The unique ID of the Form)
   * int(11)
@@ -28,8 +28,8 @@ _**nf3_forms**_ (Table of individual Forms)
   * int(11)
 * subs (The Form's number of lifetime Submissions)
   * int(11)
-```
-```
+
+
 _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
 * id (The unique ID of the Setting)
   * int(11)
@@ -47,9 +47,9 @@ _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-```
+
 ### Fields
-```
+
 _**nf3_fields**_ (Table of individual Fields)
 * id (The unique ID of the Field)
   * int(11)
@@ -76,8 +76,8 @@ _**nf3_fields**_ (Table of individual Fields)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Field was last updated)
   * datetime
-```
-```
+
+
 _**nf3_field_meta**_ (Table of Settings associated with each Field)
 * id (The unique ID of the Setting)
   * int(11)
@@ -95,9 +95,9 @@ _**nf3_field_meta**_ (Table of Settings associated with each Field)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-```
+  
 ### Actions
-```
+
 _**nf3_actions**_ (Table of individual Actions)
 * id (The unique ID of the Action)
   * int(11)
@@ -127,8 +127,8 @@ _**nf3_actions**_ (Table of individual Actions)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Action was last updated)
   * datetime
-```
-```
+
+
 _**nf3_action_meta**_ (Table of Settings associated with each Action)
 * id (The unique ID of the Setting)
   * int(11)
@@ -146,9 +146,9 @@ _**nf3_action_meta**_ (Table of Settings associated with each Action)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-```
+
 ### Objects
-```
+
 _**nf3_objects**_ (Table of non-structured Objects)
 * id (The unique ID of the Object)
   * int(11)
@@ -168,8 +168,8 @@ _**nf3_objects**_ (Table of non-structured Objects)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Object was last updated)
   * datetime
-```
-```
+
+
 _**nf3_object_meta**_ (Table of Settings associated with each Object)
 * id (The unique ID of the Setting)
   * int(11)
@@ -187,8 +187,8 @@ _**nf3_object_meta**_ (Table of Settings associated with each Object)
 * value (The value of the Setting)
   * longtext
   * COLLATE DATABASE_DEFAULT
-```
-```
+
+
 _**nf3_relationships**_ (Table of Relationships between Objects)
 * id (The unique ID of the Relationship)
   * int(11)
@@ -218,14 +218,14 @@ _**nf3_relationships**_ (Table of Relationships between Objects)
   * ON UPDATE CURRENT_TIMESTAMP
 * updated_at (The date/time the Relationship was last updated)
   * datetime
-```
-```
+
+
 _**options**_ (The default WordPress options table)
 * option_name = 'nf_form_%' WHERE % = *nf3_forms* id
 * option_value = Serialized JSON Object (The Ninja Forms Cache)
-```
+
 ### Submissions
-```
+
 _**posts**_ (The default WordPress posts table)
 * id (The unique ID of the Post)
   * bigint(20)
@@ -233,8 +233,8 @@ _**posts**_ (The default WordPress posts table)
   * AUTO_INCREMENT
   * Primary Key
 * post_type = 'nf_sub'
-```
-```
+
+
 _**postmeta**_ (The default WordPress postmeta table)
 * meta_id (The unique ID of the Metadata)
   * bigint(20)
@@ -252,4 +252,3 @@ _**postmeta**_ (The default WordPress postmeta table)
 * meta_value (The value of this record)
   * longtext
   * COLLATE DATABASE_DEFAULT
-```

--- a/DATA_STRUCTURE.md
+++ b/DATA_STRUCTURE.md
@@ -29,6 +29,7 @@ _**nf3_forms**_ (Table of individual Forms)
 * subs (The Form's number of lifetime Submissions)
   * int(11)
 
+
 _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
 * id (The unique ID of the Setting)
   * int(11)
@@ -47,3 +48,50 @@ _**nf3_form_meta**_ (Table of Settings assoicated with each Form)
   * longtext
   * COLLATE DATABASE_DEFAULT
 
+### Fields
+
+_**nf3_fields**_ (Table of individual Fields)
+* id (The unique ID of the Field)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* label (The displayable label of the Field)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* key (The administrative key of the Field)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* type (The type of Field this record represents)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+* parent_id (The Form ID this Field is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_forms* id
+* created_at (The date/time the Field was created)
+  * timestamp
+  * NOT NULL
+  * DEFAULT CURRENT_TIMESTAMP
+  * ON UPDATE CURRENT_TIMESTAMP
+* updated_at (The date/time the Field was last updated)
+  * datetime
+
+
+_**nf3_field_meta**_ (Table of Settings associated with each Field)
+* id (The unique ID of the Setting)
+  * int(11)
+  * NOT NULL
+  * AUTO_INCREMENT
+  * Primary Key
+* parent_id (The Field ID this Setting is associated with)
+  * int(11)
+  * NOT NULL
+  * Foreign Key ON *nf3_fields* id
+* key (The administrative key of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT
+  * NOT NULL
+* value (The value of the Setting)
+  * longtext
+  * COLLATE DATABASE_DEFAULT

--- a/includes/Abstracts/Migration.php
+++ b/includes/Abstracts/Migration.php
@@ -24,7 +24,16 @@ abstract class NF_Abstracts_Migration
     public function charset_collate()
     {
         global $wpdb;
-        return $wpdb->get_charset_collate();
+        // If our mysql version is 5.5.3 or higher...
+        if ( version_compare( $wpdb->db_version(), '5.5.3', '>=' ) ) {
+            // We can use mb4.
+            return 'DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci';
+        } // Otherwise...
+        else {
+            // We use standard utf8.
+            return 'DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci';
+        }
+        
     }
 
     public function _run()

--- a/includes/Database/Migrations.php
+++ b/includes/Database/Migrations.php
@@ -16,6 +16,7 @@ class NF_Database_Migrations
         $this->migrations[ 'object_meta' ]   = new NF_Database_Migrations_ObjectMeta();
         $this->migrations[ 'relationships' ] = new NF_Database_Migrations_Relationships();
         $this->migrations[ 'settings' ]      = new NF_Database_Migrations_Settings();
+        $this->migrations[ 'upgrades' ]      = new NF_Database_Migrations_Upgrades();
     }
 
     public function migrate()

--- a/includes/Database/Migrations/Upgrades.php
+++ b/includes/Database/Migrations/Upgrades.php
@@ -1,0 +1,25 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit;
+
+class NF_Database_Migrations_Upgrades extends NF_Abstracts_Migration
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'nf3_upgrades',
+            'nf_migration_create_table_upgrades'
+        );
+    }
+
+    public function run()
+    {
+        $query = "CREATE TABLE IF NOT EXISTS {$this->table_name()} (
+            `id` INT(11) NOT NULL,
+            `cache` LONGTEXT,
+            `stage` INT(11) NOT NULL DEFAULT 0,
+            PRIMARY KEY ( id )
+        ) {$this->charset_collate()};";
+
+        dbDelta( $query );
+    }
+
+}

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -199,6 +199,15 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
                     define( 'NF_PLUGIN_URL', self::$url );
                 }
 
+                $saved_version = get_option( 'ninja_forms_version' );
+                // If we have a recorded version...
+                // AND that version is less than our current version...
+                if ( $saved_version && version_compare( $saved_version, self::VERSION, '<' ) ) {
+                    // We just upgraded the plugin.
+                    $plugin_upgrade = true;
+                } else {
+                    $plugin_upgrade = false;
+                }
                 update_option( 'ninja_forms_version', self::VERSION );
                 // If we've not recorded our db version...
                 if ( ! get_option( 'ninja_forms_db_version' ) ) {
@@ -361,6 +370,13 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
                     require_once( self::$dir . 'includes/Integrations/EDD/EDD_SL_Plugin_Updater.php');
                 }
                 require_once self::$dir . 'includes/Integrations/EDD/class-extension-updater.php';
+                
+                // If Ninja Forms was just upgraded...
+                if ( $plugin_upgrade ) {
+                    // Ensure all of our tables have been defined.
+                    $migrations = new NF_Database_Migrations();
+                    $migrations->migrate();
+                }
             }
 
             add_action( 'admin_notices', array( self::$instance, 'admin_notices' ) );

--- a/ninja-forms.php
+++ b/ninja-forms.php
@@ -200,6 +200,11 @@ if( get_option( 'ninja_forms_load_deprecated', FALSE ) && ! ( isset( $_POST[ 'nf
                 }
 
                 update_option( 'ninja_forms_version', self::VERSION );
+                // If we've not recorded our db version...
+                if ( ! get_option( 'ninja_forms_db_version' ) ) {
+                    // Set it to the baseline (1.0).
+                    add_option( 'ninja_forms_db_version', '1.0', '', 'no' );
+                }
 
                 /*
                  * Register our autoloader


### PR DESCRIPTION
Requires #3538 

Changes proposed in this pull request:
- Defined tracker table as nf3_upgrades.
- Added function to ensure all Ninja Forms tables are created on plugin update.
- Modified default collation to be utf8mb4, utf8 on older mysql versions.
- Updated data structure documentation to reflect db changes.

@wpninjas/developers 
