### PR TITLE
changed the way we retrieve form data for the Add Form modal on posts

### DIFF
--- a/includes/Admin/AddFormModal.php
+++ b/includes/Admin/AddFormModal.php
@@ -25,6 +25,7 @@ class NF_Admin_AddFormModal {
         if( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ) ) ){
             return $context;
         }
+        
         $html = '<style>
             span.nf-insert-form {
                 color:#888;
@@ -50,14 +51,16 @@ class NF_Admin_AddFormModal {
          <div id="nf-insert-form-modal" style="display:none;">
             <p>
                 <?php
-                $all_forms = Ninja_Forms()->form()->get_forms();
-                $first_option = __( 'Select a form or type to search', 'ninja-forms' );
+                global $wpdb;
+                $all_forms = $wpdb->get_results( 'SELECT id, title FROM `' . $wpdb->prefix
+                    . 'nf3_forms` ORDER BY title' );
+//                $all_forms = Ninja_Forms()->form()->get_forms();
+//                $first_option = __( 'Select a form or type to search', 'ninja-forms' );
                 echo '<select class="nf-forms-combobox" id="nf-form-select" data-first-option="">';
                 echo '<option value=""></option>';
                 foreach( $all_forms as $form ) {
-                    // $form = Ninja_Forms()->form( $form_id )->get();
-                    $label = $form->get_setting( 'title' );
-                    $form_id = $form->get_id();
+                    $label = $form->title;
+                    $form_id = $form->id;
                     if ( strlen( $label ) > 30 )
                         $label = substr( $label, 0, 30 ) . '...';
 


### PR DESCRIPTION
This fixes un-necessary queries when retrieving form title and id for the 'Add Form' modal on posts/pages in the admin.

@wpninjas/developers 
