### PR TITLE
Redact removed values instead of leaving them blank.

### DIFF
--- a/includes/Actions/Save.php
+++ b/includes/Actions/Save.php
@@ -104,7 +104,20 @@ final class NF_Actions_Save extends NF_Abstracts_Action
             // If we're supposed to save this field...
             if( $save_field ) {
                 // Do so.
-	            $sub->update_field_value( $field['id'], $field['value'] );
+	            $sub->update_field_value( $field[ 'id' ], $field[ 'value' ] );
+            } // Otherwise...
+            else {
+                // If this field is not a list...
+                // AND If this field is not a checkbox...
+                // AND If this field is not a product...
+                // AND If this field is not a termslist...
+                if ( false == strpos( $field[ 'type' ], 'list' ) &&
+                    false == strpos( $field[ 'type' ], 'checkbox' ) &&
+                    'products' !== $field[ 'type' ] &&
+                    'terms' !== $field[ 'type' ] ) {
+                    // Anonymize it.
+                    $sub->update_field_value( $field[ 'id' ], '(redacted)' );
+                }
             }
         }
 

--- a/includes/Fields/ListMultiSelect.php
+++ b/includes/Fields/ListMultiSelect.php
@@ -34,7 +34,7 @@ class NF_Fields_ListMultiselect extends NF_Abstracts_List
 
         $options = '';
         foreach( $field->get_setting( 'options' ) as $option ){
-            $selected = ( in_array( $option[ 'value' ], $value ) ) ? "selected" : '';
+            $selected = ( is_array( $value ) && in_array( $option[ 'value' ], $value ) ) ? "selected" : '';
             $options .= "<option value='{$option[ 'value' ]}' $selected>{$option[ 'label' ]}</option>";
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Updated save action to replace text-based fields with (redacted).
- Fixed issue with multiselect lists in submission edit page.

@wpninjas/developers 
