### PR TITLE
Fix Textarea template

### DIFF
--- a/includes/Templates/fields-textarea.html
+++ b/includes/Templates/fields-textarea.html
@@ -1,11 +1,9 @@
 <script id="tmpl-nf-field-textarea" type="text/template">
-	<textarea id="nf-field-{{{ data.id }}}" name="nf-field-{{{ data.id }}}" aria-invalid="false" aria-describedby="nf-error-{{{ data.id }}}" class="{{{ data.renderClasses() }}} nf-element" {{{ data.renderPlaceholder() }}}" {{{ data.maybeDisabled() }}} {{{ data.maybeDisableAutocomplete() }}} {{{ data.maybeInputLimit() }}}
+	<textarea id="nf-field-{{{ data.id }}}" name="nf-field-{{{ data.id }}}" aria-invalid="false" aria-describedby="nf-error-{{{ data.id }}}" class="{{{ data.renderClasses() }}} nf-element" {{{ data.renderPlaceholder() }}} {{{ data.maybeDisabled() }}} {{{ data.maybeDisableAutocomplete() }}} {{{ data.maybeInputLimit() }}}
         aria-labelledby="nf-label-field-{{{ data.id }}}"
 
         {{{ data.maybeRequired() }}}
-    >
-        {{{ data.value }}}
-    </textarea>
+    >{{{ data.value }}}</textarea>
 </script>
 
 <!-- Rich Text Editor Templates -->


### PR DESCRIPTION
- removed extra quote
- removed blank spaces/lines in textarea value (between <textarea></textarea>

Fixes #

Changes proposed in this pull request:
-
-
-

@wpninjas/developers 
