### PR TITLE
allow merge tags to use merge tags(recursive merge tags)

### DIFF
--- a/includes/Abstracts/MergeTags.php
+++ b/includes/Abstracts/MergeTags.php
@@ -54,7 +54,7 @@ abstract class NF_Abstracts_MergeTags
 				$replace = '';
 			}
             
-            $subject = str_replace( $merge_tag[ 'tag' ], $replace, $subject );
+            $subject = $this->replace( str_replace( $merge_tag[ 'tag' ], $replace, $subject ) );
         }
 
         return $subject;


### PR DESCRIPTION

Changes proposed in this pull request:
Allow merge tags to use merge tags (i.e. I'm doing a redirect to `{field:hidden_field_215563}` and this field contains `http://myurl.com/?name={field:name_89231}`)

@wpninjas/developers 