### PR TITLE
Prevent nf_form_{$id} options from autoloading

### DIFF
--- a/includes/AJAX/Controllers/Form.php
+++ b/includes/AJAX/Controllers/Form.php
@@ -127,7 +127,7 @@ class NF_AJAX_Controllers_Form extends NF_Abstracts_Controller
         }
 
         delete_user_option( get_current_user_id(), 'nf_form_preview_' . $form_data['id'] );
-        update_option( 'nf_form_' . $form_data[ 'id' ], $form_data );
+        update_option( 'nf_form_' . $form_data[ 'id' ], $form_data, 'no' );
 
         do_action( 'ninja_forms_save_form', $form->get_id() );
 

--- a/includes/Admin/Processes/ChunkPublish.php
+++ b/includes/Admin/Processes/ChunkPublish.php
@@ -216,7 +216,7 @@ class NF_Admin_Processes_ChunkPublish extends NF_Abstracts_BatchProcess
         }
 
         delete_user_option( get_current_user_id(), 'nf_form_preview_' . $form_data['id'] );
-        update_option( 'nf_form_' . $form_data[ 'id' ], $form_data );
+        update_option( 'nf_form_' . $form_data[ 'id' ], $form_data, 'no' );
 
         do_action( 'ninja_forms_save_form', $form->get_id() );
 


### PR DESCRIPTION
[By default, options that are created with `update_option()` will be saved as auto-loading options](https://developer.wordpress.org/reference/functions/update_option/#parameters). On sites with many and/or large forms, this can result in the data needed for every form to be loaded on *every* page request; the more forms, the larger the request.

Worse yet, sites using an object cache (Memcached, Redis, etc.) will end up with giant `options:alloptions` arrays, which can then impact not only site performance but site functionality. We unwittingly stumbled upon this issue while troubleshooting a site where rewrite rules refused to flush; as it turns out, the stored cache value was north of 4MB and Redis began to refuse to write to it.

Fortunately, it's a pretty straight-forward fix: this PR explicitly sets the `$autoload` value to "no" for the `nf_form_{$ID}` options. This doesn't affect current forms, but WordPress will silently make them non-autoloading the next time the form is saved.

For existing forms, users may want to consider a direct SQL query:

```sql
UPDATE wp_options SET autoload = 'no' WHERE option_name LIKE 'nf_form_%' AND autoload = 'yes';
```

Fixes #3297.