### PR TITLE
Fixed issue with inline quantity fields not showing quantity in the f…

### DIFF
--- a/includes/MergeTags/Fields.php
+++ b/includes/MergeTags/Fields.php
@@ -134,10 +134,20 @@ final class NF_MergeTags_Fields extends NF_Abstracts_MergeTags
 
             // Skip fields without values.
             if( ! $field[ 'value' ] ) continue;
+			//Skip values of 0.00
+			if( $field['value'] == '0.00') continue;
 
             if( is_array( $field[ 'value' ] ) ) $field[ 'value' ] = implode( ', ', $field[ 'value' ] );
 
-            $return .= '<tr><td valign="top">' . apply_filters('ninja_forms_merge_label', $field[ 'label' ]) .':</td><td>' . $field[ 'value' ] . '</td></tr>';
+            //if using inline quantity then show quantity in the value column.
+			if($field[ 'product_use_quantity' ])
+			{
+            		$return .= '<tr><td valign="top">' . apply_filters('ninja_forms_merge_label', $field[ 'label' ]) .':</td><td style="padding-left:10px;">$' . $field[ 'value' ] . ' - ' . $field[ 'value' ] / str_replace("$","",$field['product_price']) .' units @ ' . $field[ 'product_price' ] . ' per unit' . '</td></tr>';
+			}
+			else
+			{
+				$return .= '<tr><td valign="top">' . apply_filters('ninja_forms_merge_label', $field[ 'label' ]) .':</td><td style="padding-left:10px;">' . $field[ 'value' ] . '</td></tr>';
+			}
         }
         $return .= '</table>';
         return $return;


### PR DESCRIPTION
…ields table merge tag when used in an email.  Also made it so that line items with zero quantity are not listed.  This is how the description of the merge tag defines it, but it was not actually working that way.

Fixes #3653 

Changes proposed in this pull request:
- Adds inline quantity to fields_table merge tag for emails
- Omits zero quantity line items from fields_table merge tag output

@wpninjas/developers 
