### PR TITLE
Fix syntax error in SQL query.

### DIFF
--- a/includes/Abstracts/Model.php
+++ b/includes/Abstracts/Model.php
@@ -855,7 +855,7 @@ class NF_Abstracts_Model
 
         $join_statement = implode( ' ', $join_statement );
 
-        $where_statement = implode( ' AND ', $where_statement );
+		$where_statement = 'AND ' . implode( ' AND ', $where_statement );
 
         // TODO: Breaks SQL. Needs more testing.
         // if( $where_statement ) $where_statement = "AND " . $where_statement;


### PR DESCRIPTION
When using the $where parameter, e.g. [ 'type' => 'save' ], the built up $where_statement array produces a syntax error, never returning any results. Simply putting 'AND ' in front of the glued array fixes it.

Should also take care of that TODO :)

Fixes #

Changes proposed in this pull request:
- prepend 'AND ' to the glued array.

@wpninjas/developers 
